### PR TITLE
Quick hacks to get it running on QEMU 9.2

### DIFF
--- a/src/boot.rs
+++ b/src/boot.rs
@@ -28,6 +28,7 @@ global_asm!(
 
     // Called from armstub8.S:
     // https://github.com/raspberrypi/tools/blob/439b6198a9b340de5998dd14a26a0d9d38a6bcac/armstubs/armstub8.S#L92
+    // See also: Linux's init code... https://github.com/raspberrypi/linux/blob/dfff38316c1284c30c68d02cc424bad0562cf253/arch/arm64/kernel/head.S
 .global kernel_entry
 kernel_entry:
     // Check core id, halt if non-zero
@@ -70,6 +71,11 @@ kernel_entry_alt:
     // ...with ELR 0x8005c
     // ...to EL1 PC 0x80a00 PSTATE 0x3c5
 drop_to_el1:
+
+    mov x5, #(1 << 31)
+    // orr x5, x5, #0x38
+    msr hcr_el2, x5
+
     mov x5, #0b0101
     msr ELR_EL2, lr
     msr SPSR_EL2, x5

--- a/src/device/uart.rs
+++ b/src/device/uart.rs
@@ -9,10 +9,72 @@ pub struct UARTInner {
 impl UARTInner {
     const UART_DR: usize = 0x00;
     const UART_FR: usize = 0x18;
+    const UART_IBRD: usize = 0x24;
+    const UART_FBRD: usize = 0x28;
+    const UART_LCRH: usize = 0x2C;
+    const UART_IMSC: usize = 0x38;
+    const UART_CR: usize = 0x30;
+    const UART_ICR: usize = 0x44;
 
-    pub fn new(base: *mut ()) -> Self {
+    pub unsafe fn new(base: *mut ()) -> Self {
         // TODO[hardware]: proper UART initialization
-        Self { base }
+        // (this is enough to convince qemu that it's initialized)
+
+        let this = Self { base };
+
+        unsafe {
+            // Disable UART0.
+            this.reg(Self::UART_CR).write(0x00000000);
+            // Setup the GPIO pin 14 && 15.
+
+            // TODO: GPIO init
+            // // Disable pull up/down for all GPIO pins & delay for 150 cycles.
+            // this.reg(Self::GPPUD).write(0x00000000);
+            // crate::sync::spin_sleep(1);
+
+            // // Disable pull up/down for pin 14,15 & delay for 150 cycles.
+            // this.reg(Self::GPPUDCLK0).write((1 << 14) | (1 << 15));
+            // crate::sync::spin_sleep(1);
+
+            // // Write 0 to GPPUDCLK0 to make it take effect.
+            // this.reg(Self::GPPUDCLK0).write(0x00000000);
+
+            // Clear pending interrupts.
+            this.reg(Self::UART_ICR).write(0x7FF);
+
+            // Set integer & fractional part of baud rate.
+            // Divider = UART_CLOCK/(16 * Baud)
+            // Fraction part register = (Fractional part * 64) + 0.5
+            // Baud = 115200.
+
+            // For Raspi3 and 4 the UART_CLOCK is system-clock dependent by default.
+            // Set it to 3Mhz so that we can consistently set the baud rate
+            // if (raspi >= 3) {
+            //     // UART_CLOCK = 30000000;
+            //     unsigned int r = (((unsigned int)(&mbox) & ~0xF) | 8);
+            //     // wait until we can talk to the VC
+            //     while ( mmio_read(MBOX_STATUS) & 0x80000000 ) { }
+            //     // send our message to property channel and wait for the response
+            //     this.reg(Self::MBOX_WRITE).write(r);
+            //     while ( (mmio_read(MBOX_STATUS) & 0x40000000) || mmio_read(MBOX_READ) != r ) { }
+            // }
+
+            // Divider = 3000000 / (16 * 115200) = 1.627 = ~1.
+            this.reg(Self::UART_IBRD).write(1);
+            // Fractional part register = (.627 * 64) + 0.5 = 40.6 = ~40.
+            this.reg(Self::UART_FBRD).write(40);
+
+            // Enable FIFO & 8 bit data transmission (1 stop bit, no parity).
+            this.reg(Self::UART_LCRH).write((1 << 4) | (1 << 5) | (1 << 6));
+
+            // Mask all interrupts.
+            this.reg(Self::UART_IMSC).write((1 << 1) | (1 << 4) | (1 << 5) | (1 << 6) |
+                                (1 << 7) | (1 << 8) | (1 << 9) | (1 << 10));
+
+            // Enable UART, receive & transfer part of UART.
+            this.reg(Self::UART_CR).write((1 << 0) | (1 << 8) | (1 << 9));
+        }
+        this
     }
 
     fn reg(&self, reg: usize) -> Volatile<u32> {


### PR DESCRIPTION
Sets a bit in `hcr_el2` to properly enable 64 bit mode, and partially initializes the UART (enough to get it working on QEMU, but probably not on actual hardware).  Proper initialization will have to wait until we have a proper device tree / device driver setup, so that we can do it without hard-coding the base addresses for the UART and GPIO registers.