### PR TITLE
Fix kernel image binary size

### DIFF
--- a/crates/kernel/script.ld
+++ b/crates/kernel/script.ld
@@ -9,7 +9,7 @@
  * Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
  */
 
-PAGE_SIZE = 64K;
+PAGE_SIZE = 16K;
 
 __rpi_phys_dram_start_addr = 0x00000;
 

--- a/crates/kernel/scripts/build.sh
+++ b/crates/kernel/scripts/build.sh
@@ -2,5 +2,5 @@
 cargo clean
 cargo rustc --release --target aarch64-unknown-none-softfloat -- \
     -C link-arg=--script=./crates/kernel/script.ld \
-    -C relocation-model=pic
+    -C relocation-model=static
 llvm-objcopy -O binary ../../target/aarch64-unknown-none-softfloat/release/kernel kernel.bin


### PR DESCRIPTION
The linker was including the `.bss` section in the generated kernel image, due to `relocation-model=pic` creating a `.got` section; this patch fixes that, and reduces the alignment requirement to decrease the padding between the end of the kernel and the start of the data segment.