### PR TITLE
Initial VM implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 kernel.bin
 .gdb_history
 .vscode
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 kernel.bin
 .gdb_history
+.vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "bitflags"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+
+[[package]]
 name = "bytemuck"
 version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,6 +25,7 @@ dependencies = [
 name = "kernel"
 version = "0.1.0"
 dependencies = [
+ "bitflags",
  "bytemuck",
  "device-tree",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ opt-level = 2
 strip = false
 incremental = false
 debug = 2
+panic = "abort"
 
 [profile.dev]
 incremental = false
+panic = "abort"

--- a/crates/kernel/Cargo.toml
+++ b/crates/kernel/Cargo.toml
@@ -6,7 +6,9 @@ edition = "2021"
 [[bin]]
 name = "kernel"
 path = "src/main.rs"
+panic = "abort"
 
 [dependencies]
+bitflags = "2.8.0"
 bytemuck = { version = "1.19.0", default-features = false }
 device-tree = { path = "../device-tree" }

--- a/crates/kernel/Cargo.toml
+++ b/crates/kernel/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 [[bin]]
 name = "kernel"
 path = "src/main.rs"
-panic = "abort"
 
 [dependencies]
 bitflags = "2.8.0"

--- a/crates/kernel/script.ld
+++ b/crates/kernel/script.ld
@@ -15,7 +15,7 @@ __rpi_phys_dram_start_addr = 0x00000;
 
 # The base address at which the Raspberry pi bootloader loads the
 # kernel into physical memory.
-__rpi_phys_binary_start_addr = 0x80000;
+__rpi_phys_binary_start_addr = 0xFFFFFFFFFE080000;
 
 ENTRY(__rpi_phys_binary_start_addr)
 
@@ -34,8 +34,6 @@ PHDRS {
 }
 
 SECTIONS {
-    . = __rpi_phys_dram_start_addr;
-
     . = __rpi_phys_binary_start_addr;
     __code_start = .;
     .text : {

--- a/crates/kernel/src/boot.rs
+++ b/crates/kernel/src/boot.rs
@@ -98,7 +98,7 @@ drop_to_el1:
     ldr x5, =0xFFFFFFFFFE000000 // TODO: slightly cleaner way of encoding this?
     orr lr, lr, x5
     msr ELR_EL2, lr
-    ldr x5, =0b0000000011111111 // Entry 0 is normal memory, entry 1 is device memory
+    ldr x5, =0b010001000000000011111111 // Entry 0 is normal memory, entry 1 is device memory, 2 = normal noncacheable memory
     msr MAIR_EL1, x5
     isb
     eret

--- a/crates/kernel/src/device/mailbox.rs
+++ b/crates/kernel/src/device/mailbox.rs
@@ -332,7 +332,7 @@ impl VideoCoreMailbox {
         // println!("{:?}", bytemuck::cast_slice_mut::<_, u32>(&mut buffer));
         println!("Response: {response:#010x}\nbuffer: {buffer_ptr:#010x}, {buffer_size:#010x}, {pitch:#010x}");
 
-        let ptr = unsafe { memory::map_physical(buffer_ptr as usize, buffer_size) };
+        let ptr = unsafe { memory::map_physical_noncacheable(buffer_ptr as usize, buffer_size) };
         let ptr = ptr.as_ptr().cast::<u128>();
         assert!(ptr.is_aligned());
 

--- a/crates/kernel/src/exceptions.rs
+++ b/crates/kernel/src/exceptions.rs
@@ -1,4 +1,4 @@
-use core::arch::global_asm;
+use core::arch::{asm, global_asm};
 
 use crate::thread::Context;
 use crate::{halt, uart};
@@ -163,7 +163,16 @@ unsafe extern "C" fn exception_handler_example(
     let _insn_len = if ((esr >> 25) & 1) != 0 { 4 } else { 2 };
 
     if uart::UART.is_initialized() {
-        println!("Recieved exception: elr={elr:#x} spsr={spsr:#010x} esr={esr:#010x} (class {exception_class:#x} / {class_name}) {arg}");
+        println!("Received exception: elr={elr:#x} spsr={spsr:#010x} esr={esr:#010x} (class {exception_class:#x} / {class_name}) {arg}");
+        let far_el1: usize;
+        unsafe {
+            asm! {
+                "mrs {}, far_el1",
+                out(reg) far_el1,
+                options(nomem, nostack, preserves_flags)
+            }
+        }
+        println!("(Faulting address, if relevant: 0x{far_el1:X})");
     }
 
     match exception_class {

--- a/crates/kernel/src/heap.rs
+++ b/crates/kernel/src/heap.rs
@@ -1,4 +1,4 @@
-use alloc::alloc::{GlobalAlloc, Layout};
+use alloc::alloc::{handle_alloc_error, GlobalAlloc, Layout};
 use core::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
 
 // TODO: implement a proper allocator
@@ -54,8 +54,7 @@ unsafe impl GlobalAlloc for BumpAllocator {
 
         let max = self.max.load(Ordering::SeqCst);
         if start.next_multiple_of(align) + size >= max {
-            self.offset.store(max, Ordering::SeqCst);
-            panic!("Heap full");
+            handle_alloc_error(layout);
         }
 
         let alloc_offset = start.next_multiple_of(align);

--- a/crates/kernel/src/main.rs
+++ b/crates/kernel/src/main.rs
@@ -49,7 +49,7 @@ pub unsafe extern "C" fn kernel_entry_rust(x0: u32, _x1: u64, _x2: u64, _x3: u64
     let id = core_id() & 3;
 
     // TODO: proper heap allocator, and physical memory allocation for heap space
-    unsafe { heap::ALLOCATOR.init(0xFFFF_FFFF_FE10_0000 as *mut (), 0x100000) };
+    unsafe { heap::ALLOCATOR.init(0xFFFF_FFFF_FE20_0000 as *mut (), 0x20_0000 * 13) };
 
     // TODO: device tree /soc/serial with compatible:arm,pl011
     let uart_base = unsafe { memory::map_device(0x3f201000) }.as_ptr();
@@ -194,7 +194,6 @@ fn kernel_main(device_tree: device_tree::DeviceTree) {
     barrier.sync();
     println!("End of preemption test");
 
-    todo!("Fix mailbox accesses");
     let mut surface = unsafe { mailbox.get_framebuffer() };
 
     vsync_tearing_demo(&mut surface);

--- a/crates/kernel/src/memory/machine.rs
+++ b/crates/kernel/src/memory/machine.rs
@@ -226,7 +226,7 @@ impl TcrEl1 {
             .union(Self::from_bits_retain((tg0 as u64) << 14))
     }
 
-    const fn set_t1sz(&self, t1sz: u8) -> Self {
+    const fn set_t1sz(self, t1sz: u8) -> Self {
         assert!(t1sz < (1 << 6));
         self.difference(Self::T1SZ)
             .union(Self::from_bits_retain((t1sz as u64) << 16))
@@ -291,7 +291,7 @@ impl TableDescriptor {
         assert!(pa < (1 << 52), "field size mismatch");
         assert!(pa % (1 << 12) == 0, "alignment mismatch");
         self.difference(Self::NEXT_ADDR)
-            .union(Self::from_bits_retain((pa as u64)))
+            .union(Self::from_bits_retain(pa as u64))
     }
 
     pub const fn is_valid(self) -> bool {
@@ -322,7 +322,7 @@ impl LeafDescriptor {
         assert!(pa < (1 << 52), "field size mismatch");
         assert!(pa % (1 << 12) == 0, "alignment mismatch");
         self.difference(Self::OA)
-            .union(Self::from_bits_retain((pa as u64)))
+            .union(Self::from_bits_retain(pa as u64))
     }
 
     pub const fn clear_pxn(self) -> Self {

--- a/crates/kernel/src/memory/machine.rs
+++ b/crates/kernel/src/memory/machine.rs
@@ -1,0 +1,384 @@
+use core::arch::asm;
+
+use bitflags::bitflags;
+
+bitflags! {
+    // TODO: Address feature-dependent bits after TBI1
+    #[derive(Clone, Copy, Debug)]
+    pub struct TcrEl1: u64 {
+        /// The size offset of the memory region addressed by TTBR0_EL1. The region size is 2(64-T0SZ) bytes.
+        ///
+        /// The maximum and minimum possible values for T0SZ depend on the level of translation table and the memory translation granule size.
+        const T0SZ = 0b111111;
+        /// Translation table walk disable for translations using TTBR0_EL1.
+        ///
+        /// This bit controls whether a translation table walk is performed on a TLB miss, for an address that is translated using TTBR0_EL1.
+        ///
+        /// Always 0b0 to allow translation table walks
+        const EPD0 = 0b1 << 7;
+        /// Inner cacheability attribute for memory associated with translation table walks using TTBR0_EL1.
+        ///
+        /// Always 0b01 as all normal memory is Write-Back Read-Allocate Write-Allocate Cacheable.
+        const IRGN0 = 0b11 << 8;
+        /// Outer cacheability attribute for memory associated with translation table walks using TTBR0_EL1.
+        ///
+        /// Always 0b01 as all normal memory is Write-Back Read-Allocate Write-Allocate Cacheable.
+        const ORGN0 = 0b11 << 10;
+        /// Shareability attribute for memory associated with translation table walks using TTBR0_EL1.
+        ///
+        /// Always 0b10 as all normal memory is Outer Shareable
+        const SH0 = 0b11 << 12;
+        /// Granule size for the TTBR0_EL1.
+        ///
+        /// 0b00 4KB
+        /// 0b01 64KB
+        /// 0b10 16KB
+        const TG0 = 0b11 << 14;
+        /// The size offset of the memory region addressed by TTBR1_EL1. The region size is 2(64-T0SZ) bytes.
+        ///
+        /// The maximum and minimum possible values for T0SZ depend on the level of translation table and the memory translation granule size.
+        const T1SZ = 0b111111 << 16;
+        /// Selects whether TTBR0_EL1 or TTBR1_EL1 defines the ASID.
+        ///
+        /// Always 0b0 as we always use TTBR0_EL1 to define the ASID
+        const A1 = 0b1 << 22;
+        /// Translation table walk disable for translations using TTBR1_EL1.
+        ///
+        /// This bit controls whether a translation table walk is performed on a TLB miss, for an address that is translated using TTBR1_EL1
+        ///
+        /// Always 0b0 to allow translation table walks
+        const EPD1 = 0b1 << 23;
+        /// Inner cacheability attribute for memory associated with translation table walks using TTBR1_EL1.
+        ///
+        /// Always 0b01 as all normal memory is Write-Back Read-Allocate Write-Allocate Cacheable.
+        const IRGN1 = 0b11 << 24;
+        /// Outer cacheability attribute for memory associated with translation table walks using TTBR1_EL1.
+        ///
+        /// Always 0b01 as all normal memory is Write-Back Read-Allocate Write-Allocate Cacheable.
+        const ORGN1 = 0b11 << 26;
+        /// Shareability attribute for memory associated with translation table walks using TTBR1_EL1.
+        ///
+        /// Always 0b10 as all normal memory is Outer Shareable
+        const SH1 = 0b11 << 28;
+        /// Granule size for the TTBR0_EL1.
+        ///
+        /// 0b01 16KB.
+        /// 0b10 4KB.
+        /// 0b11 64KB.
+        const TG1 = 0b11 << 30;
+        /// Intermediate Physical Address Size.
+        ///
+        /// 0b000 32 bits, 4GB.
+        /// 0b001 36 bits, 64GB.
+        /// 0b010 40 bits, 1TB.
+        /// 0b011 42 bits, 4TB.
+        /// 0b100 44 bits, 16TB.
+        /// 0b101 48 bits, 256TB.
+        /// 0b110 52 bits, 4PB.
+        const IPS = 0b111 << 32;
+
+        /// ASID Size.
+        /// 0b0 8 bit - the upper 8 bits of TTBR0_EL1 and TTBR1_EL1 are ignored by hardware for every purpose except reading back the register, and are treated as if they are all zeros for when used for allocation and matching entries in the TLB.
+        /// 0b1 16 bit - the upper 16 bits of TTBR0_EL1 and TTBR1_EL1 are used for allocation and matching in the TLB.
+        const AS = 0b1 << 36;
+
+        /// Top Byte ignored. Indicates whether the top byte of an address is used for address match for the TTBR0_EL1 region, or ignored and used for tagged addresses.
+        /// 0b0 Top Byte used in the address calculation.
+        /// 0b1 Top Byte ignored in the address calculation.
+        const TBI0 = 0b1 << 37;
+
+        /// Top Byte ignored. Indicates whether the top byte of an address is used for address match for the TTBR1_EL1 region, or ignored and used for tagged addresses.
+        /// 0b0 Top Byte used in the address calculation.
+        /// 0b1 Top Byte ignored in the address calculation.
+        const TBI1 = 0b1 << 37;
+    }
+
+    // TODO: Address feature-dependent CnP bit
+    #[derive(Clone, Copy, Debug)]
+    pub struct TtbrEl1: u64 {
+        /// Translation table base address:
+        /// * Bits A[47:x] of the stage 1 translation table base address bits are in register bits[47:x].
+        /// * Bits A[(x-1):0] of the stage 1 translation table base address are zero.
+        ///
+        /// Address bit x is the minimum address bit required to align the translation table to the size of the table. The AArch64 Virtual Memory System Architecture chapter describes how x is calculated based on the value of TCR_EL1.T0SZ, the translation stage, and the translation granule size.
+        const BADDR = ((1 << 47) - 1) << 1;
+
+        /// An ASID for the translation table base address. The TCR_EL1.A1 field selects either TTBR0_EL1.ASID or TTBR1_EL1.ASID.
+        ///
+        /// If the implementation has only 8 bits of ASID, then the upper 8 bits of this field are RES0.
+        ///
+        /// By default we select TTBR0_EL1 as the ASID
+        const ASID = ((1 << 16) - 1) << 48;
+    }
+
+    // TODO: Double-check nT bit
+    /// Block and page descriptors; the ends of a translation table walk
+    #[derive(Clone, Copy, Debug)]
+    pub struct LeafDescriptor: u64 {
+        /// Valid descriptor.
+        const VALID = 0b1;
+        /// Whether the descriptor is for a block (huge page) or page (4KB/16KB/64KB)
+        const IS_PAGE_DESCRIPTOR = 0b1 << 1;
+        // TODO
+        const ATTR_IDX = 0b111 << 2;
+        // Used if the access is from Secure state, from Realm state using the EL2 or EL2&0 translation regimes, or from Root state.
+        const NS = 0b1 << 5;
+        const UNPRIVILEGED_ACCESS = 0b1 << 6;
+        const READ_ONLY = 0b1 << 7;
+        const SHAREABILITY = 0b11 << 8;
+        const ACCESSED = 0b1 << 10;
+        const NOT_GLOBAL = 0b1 << 11;
+        const OA = ((1 << 36) - 1) << 12;
+        const GP = 0b1 << 50;
+        const DBM = 0b1 << 51;
+        const CONTIGUOUS = 0b1 << 52;
+        const PXN = 0b1 << 53;
+        const UXN = 0b1 << 54;
+    }
+
+    // TODO: Fill this in when multilevel translation is used
+    #[derive(Clone, Copy, Debug)]
+    pub struct TableDescriptor: u64 {
+        /// Valid descriptor.
+        const VALID = 0b1;
+        /// Always 1
+        const IS_TABLE_DESCRIPTOR = 0b1 << 1;
+        const NEXT_ADDR = ((1 << 36) - 1) << 12;
+    }
+
+    pub struct ParEl1Success: u64 {
+        /// Indicates whether the instruction performed a successful address translation. 0 for the success case
+        const FAULT = 0b1;
+        /// Shareability attribute, for the returned output address.
+        ///
+        /// * 0b00 Non-shareable.
+        /// * 0b10 Outer Shareable (or Device memory, or Normal memory with both Inner Non-cacheable and Outer Non-cacheable attributes).
+        /// * 0b11 Inner Shareable.
+        ///
+        /// The value returned in this field can be the resulting attribute, as determined by any permitted
+        /// implementation choices and any applicable configuration bits, instead of the value that appears in
+        /// the Translation table descriptor.
+        const SH = 0b11 << 7;
+        const PA = ((1 << 40) - 1) << 12;
+        /// Memory attributes for the returned output address. This field uses the same encoding as the Attr<n> fields in MAIR_EL1.
+        ///
+        /// The value returned in this field can be the resulting attribute that is actually implemented by the
+        /// implementation, as determined by any permitted implementation choices and any applicable
+        /// configuration bits, instead of the value that appears in the Translation table descriptor.
+        const ATTR = ((1 << 8) - 1) << 56;
+    }
+
+    pub struct ParEl1Failure: u64 {
+        /// Indicates whether the instruction performed a successful address translation. 1 for the failure case
+        const FAULT = 0b1;
+        /// Fault status code, as shown in the Data Abort exception ESR encoding.
+        const FST = 0b111111 << 1;
+    }
+}
+
+/// A descriptor in a non-last level translation table that may point to further translation tables or an output block translation
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union TranslationDescriptor {
+    pub table: TableDescriptor,
+    pub leaf: LeafDescriptor,
+}
+
+/// A translation table.
+///
+/// Note that alignment varies based on the configured translation process, and so must be checked at runtime.
+#[repr(C)]
+pub struct TranslationTable(pub [TranslationDescriptor]);
+
+/// A last level translation table
+#[repr(C)]
+pub struct LeafTable(pub [LeafDescriptor]);
+
+impl TcrEl1 {
+    const fn set_t0sz(self, t0sz: u8) -> Self {
+        assert!(t0sz < (1 << 6), "field size mismatch");
+        self.difference(Self::T0SZ)
+            .union(Self::from_bits_retain(t0sz as u64))
+    }
+
+    const fn set_irgn0(self, irgn0: u8) -> Self {
+        assert!(irgn0 < (1 << 2), "field size mismatch");
+        self.difference(Self::IRGN0)
+            .union(Self::from_bits_retain((irgn0 as u64) << 8))
+    }
+
+    const fn set_orgn0(self, orgn0: u8) -> Self {
+        assert!(orgn0 < (1 << 2), "field size mismatch");
+        self.difference(Self::ORGN0)
+            .union(Self::from_bits_retain((orgn0 as u64) << 10))
+    }
+
+    const fn set_sh0(self, sh0: u8) -> Self {
+        assert!(sh0 < (1 << 2), "field size mismatch");
+        self.difference(Self::SH0)
+            .union(Self::from_bits_retain((sh0 as u64) << 12))
+    }
+
+    const fn set_tg0(self, tg0: u8) -> Self {
+        assert!(tg0 < (1 << 2), "field size mismatch");
+        assert!(tg0 != 0b11, "reserved encoding");
+        self.difference(Self::TG0)
+            .union(Self::from_bits_retain((tg0 as u64) << 14))
+    }
+
+    const fn set_t1sz(&self, t1sz: u8) -> Self {
+        assert!(t1sz < (1 << 6));
+        self.difference(Self::T1SZ)
+            .union(Self::from_bits_retain((t1sz as u64) << 16))
+    }
+
+    const fn set_irgn1(self, irgn1: u8) -> Self {
+        assert!(irgn1 < (1 << 2), "field size mismatch");
+        self.difference(Self::IRGN1)
+            .union(Self::from_bits_retain((irgn1 as u64) << 24))
+    }
+
+    const fn set_orgn1(self, orgn1: u8) -> Self {
+        assert!(orgn1 < (1 << 2), "field size mismatch");
+        self.difference(Self::ORGN1)
+            .union(Self::from_bits_retain((orgn1 as u64) << 26))
+    }
+
+    const fn set_sh1(self, sh1: u8) -> Self {
+        assert!(sh1 < (1 << 2), "field size mismatch");
+        self.difference(Self::SH1)
+            .union(Self::from_bits_retain((sh1 as u64) << 28))
+    }
+
+    const fn set_tg1(self, tg1: u8) -> Self {
+        assert!(tg1 < (1 << 2), "field size mismatch");
+        assert!(tg1 != 0b00, "reserved encoding");
+        self.difference(Self::TG1)
+            .union(Self::from_bits_retain((tg1 as u64) << 30))
+    }
+
+    const fn set_ips(self, ips: u8) -> Self {
+        assert!(ips < (1 << 3), "field size mismatch");
+        assert!(ips != 0b111, "reserved encoding");
+        self.difference(Self::IPS)
+            .union(Self::from_bits_retain((ips as u64) << 32))
+    }
+
+    pub const fn default() -> Self {
+        Self::empty()
+            .set_t0sz(0)
+            .difference(Self::EPD0)
+            .set_irgn0(0b01)
+            .set_orgn0(0b01)
+            .set_sh0(0b10)
+            .set_tg0(0b00)
+            .set_t1sz(39) // 25 bits of address translation
+            .difference(Self::A1)
+            .difference(Self::EPD1)
+            .set_irgn1(0b01)
+            .set_orgn1(0b01)
+            .set_sh1(0b10)
+            .set_tg1(0b10) // 4KB kernel pages
+            .set_ips(0b101)
+            .union(Self::AS)
+            .difference(Self::TBI0)
+            .difference(Self::TBI1)
+    }
+}
+
+impl TableDescriptor {
+    const fn set_pa(self, pa: usize) -> Self {
+        assert!(pa < (1 << 52), "field size mismatch");
+        assert!(pa % (1 << 12) == 0, "alignment mismatch");
+        self.difference(Self::NEXT_ADDR)
+            .union(Self::from_bits_retain((pa as u64)))
+    }
+
+    pub const fn is_valid(self) -> bool {
+        self.contains(Self::VALID)
+    }
+
+    pub const fn new(pa: usize) -> Self {
+        Self::empty()
+            .union(Self::VALID)
+            .union(Self::IS_TABLE_DESCRIPTOR)
+            .set_pa(pa)
+    }
+}
+
+impl LeafDescriptor {
+    const fn set_sh(self, sh: u8) -> Self {
+        assert!(sh != 0b01, "reserved encoding");
+        assert!(sh < (1 << 2), "field size mismatch");
+        self.difference(Self::SHAREABILITY)
+            .union(Self::from_bits_retain((sh as u64) << 8))
+    }
+
+    pub const fn set_global(self) -> Self {
+        self.difference(Self::NOT_GLOBAL)
+    }
+
+    const fn set_pa(self, pa: usize) -> Self {
+        assert!(pa < (1 << 52), "field size mismatch");
+        assert!(pa % (1 << 12) == 0, "alignment mismatch");
+        self.difference(Self::OA)
+            .union(Self::from_bits_retain((pa as u64)))
+    }
+
+    pub const fn clear_pxn(self) -> Self {
+        self.difference(Self::PXN)
+    }
+
+    pub const fn is_valid(self) -> bool {
+        self.contains(Self::VALID)
+    }
+
+    pub const fn set_mair(self, mair: u8) -> Self {
+        assert!(mair < (1 << 3), "field size mismatch");
+
+        self.difference(Self::ATTR_IDX)
+            .union(Self::from_bits_retain((mair as u64) << 2))
+    }
+
+    pub const fn new(pa: usize) -> Self {
+        Self::empty()
+            .union(Self::VALID)
+            .union(Self::IS_PAGE_DESCRIPTOR)
+            .difference(Self::UNPRIVILEGED_ACCESS)
+            .difference(Self::READ_ONLY)
+            .set_sh(0b10) // outer shareable
+            .union(Self::ACCESSED)
+            .union(Self::NOT_GLOBAL)
+            .set_pa(pa)
+            .union(Self::PXN)
+            .union(Self::UXN)
+    }
+}
+
+impl ParEl1Success {
+    pub const fn base_pa(self) -> u64 {
+        self.intersection(Self::PA).bits()
+    }
+}
+
+#[inline]
+pub fn at_s1e1r(va: usize) -> Result<ParEl1Success, ParEl1Failure> {
+    let par_el1: u64;
+    // When an address translation instruction is executed, explicit synchronization is required to guarantee the result is visible to subsequent direct reads of PAR_EL1.
+    unsafe {
+        asm! {
+            "at s1e1r, {x}",
+            "isb",
+            "mrs {x}, par_el1",
+            x = inlateout(reg) va => par_el1,
+            options(readonly, preserves_flags, nostack)
+        }
+    };
+    if par_el1 & 1 == 0 {
+        // No fault
+        Ok(ParEl1Success::from_bits_retain(par_el1))
+    } else {
+        // Fault
+        Err(ParEl1Failure::from_bits_retain(par_el1))
+    }
+}

--- a/crates/kernel/src/memory/mod.rs
+++ b/crates/kernel/src/memory/mod.rs
@@ -1,0 +1,24 @@
+mod machine;
+mod vmm;
+
+use machine::{at_s1e1r, LeafDescriptor};
+pub use vmm::{map_device, map_physical};
+
+pub const INIT_TCR_EL1: u64 = machine::TcrEl1::default().bits();
+pub const INIT_TRANSLATION: u64 = LeafDescriptor::new(0)
+    .set_global()
+    .clear_pxn()
+    .difference(LeafDescriptor::IS_PAGE_DESCRIPTOR)
+    .bits();
+
+pub fn physical_addr(va: usize) -> Option<u64> {
+    at_s1e1r(va)
+        .ok()
+        .map(|res| res.base_pa() + (va & 0xFFF) as u64)
+}
+
+pub unsafe fn init() {
+    unsafe {
+        vmm::init();
+    }
+}

--- a/crates/kernel/src/memory/mod.rs
+++ b/crates/kernel/src/memory/mod.rs
@@ -25,7 +25,8 @@ pub unsafe fn init() {
     }
 }
 
-pub fn clean_physical_buffer_for_device(va: *mut (), bytes: usize) {
+// Note: this may not need to be unsafe
+pub unsafe fn clean_physical_buffer_for_device(va: *mut (), bytes: usize) {
     let va = va.addr();
     for ptr in va..(va + bytes) {
         // clean each byte
@@ -47,7 +48,7 @@ pub fn clean_physical_buffer_for_device(va: *mut (), bytes: usize) {
         }
     }
 }
-pub fn invalidate_physical_buffer_for_device(va: *mut (), bytes: usize) {
+pub unsafe fn invalidate_physical_buffer_for_device(va: *mut (), bytes: usize) {
     // enforce memory barrier between this and prior memory operations
     // probably needs to be inserted (?) at some point after the device work completes, and this is a reasonable point
     unsafe {

--- a/crates/kernel/src/memory/mod.rs
+++ b/crates/kernel/src/memory/mod.rs
@@ -1,6 +1,8 @@
 mod machine;
 mod vmm;
 
+use core::arch::asm;
+
 use machine::{at_s1e1r, LeafDescriptor};
 pub use vmm::{map_device, map_physical};
 
@@ -20,5 +22,50 @@ pub fn physical_addr(va: usize) -> Option<u64> {
 pub unsafe fn init() {
     unsafe {
         vmm::init();
+    }
+}
+
+pub fn clean_physical_buffer_for_device(va: *mut (), bytes: usize) {
+    let va = va.addr();
+    for ptr in va..(va + bytes) {
+        // clean each byte
+        // TODO: only invoke the cleaning once per cache line by using the cache registers to find line width
+        unsafe {
+            asm! {
+                "dc cvac, {ptr}",
+                ptr = in(reg) ptr,
+                options(readonly, nostack, preserves_flags)
+            }
+        }
+    }
+    // enforce memory barrier between this and subsequent memory operations
+    // must be inserted at some point before the device access, and this is a reasonable point
+    unsafe {
+        asm! {
+            "dmb sy",
+            options(readonly, nostack, preserves_flags)
+        }
+    }
+}
+pub fn invalidate_physical_buffer_for_device(va: *mut (), bytes: usize) {
+    // enforce memory barrier between this and prior memory operations
+    // probably needs to be inserted (?) at some point after the device work completes, and this is a reasonable point
+    unsafe {
+        asm! {
+            "dmb sy",
+            options(readonly, nostack, preserves_flags)
+        }
+    }
+    let va = va.addr();
+    for ptr in va..(va + bytes) {
+        // invalidate each byte
+        // TODO: only invoke the invalidating once per cache line by using the cache registers to find line width
+        unsafe {
+            asm! {
+                "dc ivac, {ptr}",
+                ptr = in(reg) ptr,
+                options(readonly, nostack, preserves_flags)
+            }
+        }
     }
 }

--- a/crates/kernel/src/memory/mod.rs
+++ b/crates/kernel/src/memory/mod.rs
@@ -4,7 +4,7 @@ mod vmm;
 use core::arch::asm;
 
 use machine::{at_s1e1r, LeafDescriptor};
-pub use vmm::{map_device, map_physical};
+pub use vmm::{map_device, map_physical, map_physical_noncacheable};
 
 pub const INIT_TCR_EL1: u64 = machine::TcrEl1::default().bits();
 pub const INIT_TRANSLATION: u64 = LeafDescriptor::new(0)

--- a/crates/kernel/src/memory/vmm.rs
+++ b/crates/kernel/src/memory/vmm.rs
@@ -1,0 +1,88 @@
+use core::{
+    arch::asm,
+    ptr::{self, addr_of, NonNull},
+};
+
+use super::{
+    machine::{LeafDescriptor, TableDescriptor, TranslationDescriptor},
+    physical_addr,
+};
+
+#[repr(C, align(256))]
+struct KernelTranslationTable([TranslationDescriptor; 32]);
+
+const PG_SZ: usize = 0x1000;
+
+#[repr(C, align(4096))]
+struct KernelLeafTable([LeafDescriptor; PG_SZ / 8]);
+
+fn virt_addr_base() -> NonNull<()> {
+    NonNull::new(ptr::with_exposed_provenance_mut(0xFFFF_FFFF_FE00_0000)).unwrap()
+}
+
+/// only call once!
+pub unsafe fn init() {
+    unsafe {
+        KERNEL_TRANSLATION_TABLE.0[1] = TranslationDescriptor {
+            table: TableDescriptor::new(
+                physical_addr(addr_of!(KERNEL_LEAF_TABLE).addr()).unwrap() as usize
+            ),
+        };
+    }
+}
+
+/// not thread safe
+pub unsafe fn map_device(pa: usize) -> NonNull<()> {
+    let pa_aligned = (pa / PG_SZ) * PG_SZ;
+    let table = unsafe { &mut KERNEL_LEAF_TABLE };
+    let (idx, entry) = table
+        .0
+        .iter_mut()
+        .enumerate()
+        .find(|(_, desc)| !desc.is_valid())
+        .unwrap();
+    *entry = LeafDescriptor::new(pa_aligned).set_mair(1).set_global();
+    unsafe {
+        asm! {
+            "dsb ISH",
+            options(readonly, nostack, preserves_flags)
+        }
+    }
+    unsafe { virt_addr_base().byte_add(0x20_0000 + idx * PG_SZ + (pa - pa_aligned)) }
+}
+
+/// not thread safe
+pub unsafe fn map_physical(pa_start: usize, size: usize) -> NonNull<()> {
+    let pg_aligned_start = (pa_start / PG_SZ) * PG_SZ;
+    println!("a {pg_aligned_start:X} st {pa_start:X} sz {size:X} ");
+    let table = unsafe { &mut KERNEL_LEAF_TABLE };
+    let idx = table
+        .0
+        .iter_mut()
+        .position(|desc| !desc.is_valid())
+        .unwrap();
+    for (pg, pg_idx) in (pg_aligned_start..(pa_start + size))
+        .step_by(PG_SZ)
+        .zip(idx..)
+    {
+        table.0[pg_idx] = LeafDescriptor::new(pg).set_global();
+    }
+    unsafe {
+        asm! {
+            "dsb ISH",
+            options(readonly, nostack, preserves_flags)
+        }
+    }
+    unsafe { virt_addr_base().byte_add(0x20_0000 + idx * PG_SZ + (pa_start - pg_aligned_start)) }
+}
+
+#[no_mangle]
+static mut KERNEL_LEAF_TABLE: KernelLeafTable =
+    KernelLeafTable([LeafDescriptor::empty(); PG_SZ / 8]);
+
+#[no_mangle]
+static mut KERNEL_TRANSLATION_TABLE: KernelTranslationTable = KernelTranslationTable(
+    [TranslationDescriptor {
+        table: TableDescriptor::empty(),
+    }; 32],
+);

--- a/crates/kernel/src/memory/vmm.rs
+++ b/crates/kernel/src/memory/vmm.rs
@@ -113,6 +113,37 @@ pub unsafe fn map_physical(pa_start: usize, size: usize) -> NonNull<()> {
     }
 }
 
+/// not thread safe
+pub unsafe fn map_physical_noncacheable(pa_start: usize, size: usize) -> NonNull<()> {
+    let pg_aligned_start = (pa_start / PG_SZ) * PG_SZ;
+    let table = &raw mut KERNEL_LEAF_TABLE;
+    let table_base = table.cast::<LeafDescriptor>();
+
+    let idx = unsafe { first_unused_virt_page(table) };
+    let idx = idx.expect("Out of space in kernel page table!");
+
+    for (pg, pg_idx) in (pg_aligned_start..(pa_start + size))
+        .step_by(PG_SZ)
+        .zip(idx..)
+    {
+        let entry = unsafe { table_base.add(pg_idx) };
+        assert!(!unsafe { entry.read() }.is_valid());
+        let desc = LeafDescriptor::new(pg).set_global().set_mair(2);
+        unsafe { entry.write(desc) };
+    }
+
+    unsafe {
+        asm! {
+            "dsb ISH",
+            options(readonly, nostack, preserves_flags)
+        }
+    }
+    // TEMP: Hardcoded offsets
+    unsafe {
+        virt_addr_base().byte_add(0x20_0000 * 14 + idx * PG_SZ + (pa_start - pg_aligned_start))
+    }
+}
+
 #[no_mangle]
 static mut KERNEL_LEAF_TABLE: KernelLeafTable =
     KernelLeafTable([LeafDescriptor::empty(); PG_SZ / 8 * 2]);

--- a/crates/kernel/src/runtime.rs
+++ b/crates/kernel/src/runtime.rs
@@ -23,8 +23,5 @@ fn panic_handler(info: &PanicInfo) -> ! {
         );
     }
     // TODO: write error message to a fixed location in memory and reset?
-
-    unsafe {
-        asm!("udf #0", options(noreturn));
-    }
+    halt();
 }


### PR DESCRIPTION
* Moves the kernel into the higher half of the address space.
* Adds basic support for mapping a device into the kernel address space.
* Adds basic support for mapping a region of physical memory into the kernel address space.
* Adds support for extracting physical addresses from virtual addresses
* Adds support for dealing with physical buffers
  - Flushing the cache to main memory for writing to devices via buffers
  - Invalidating the cache when reading from devices via buffers