### PR TITLE
Minimal usermode implementation

### DIFF
--- a/crates/kernel/examples/user.rs
+++ b/crates/kernel/examples/user.rs
@@ -1,0 +1,89 @@
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+extern crate kernel;
+
+use kernel::*;
+
+use core::arch::global_asm;
+
+global_asm!(
+    "
+.global user_code_start, user_code_end
+user_code_start:
+    svc 2
+
+.balign 4
+user_code_end:
+    udf #2
+    "
+);
+
+#[allow(improper_ctypes)]
+extern "C" {
+    static user_code_start: ();
+    static user_code_end: ();
+}
+
+#[no_mangle]
+extern "Rust" fn kernel_main(_device_tree: device_tree::DeviceTree) {
+    println!("| starting kernel_main");
+
+    // Create user region (mapped at 0x20_000 in virtual memory)
+    let (user_region, ttbr0) = unsafe { crate::arch::memory::create_user_region() };
+
+    // Mark current thread as using TTBR0, so that preemption saves
+    // and restores the register.
+    context::CORES.with_current(|core| {
+        let mut thread = core.thread.take().unwrap();
+        thread.user_regs = Some(thread::UserRegs {
+            sp_el0: 0,
+            ttbr0_el1: ttbr0,
+            usermode: false,
+        });
+        core.thread.set(Some(thread));
+    });
+    // Enable the user-mode address space in this thread
+    unsafe { core::arch::asm!("msr TTBR0_EL1, {0}", "isb", in(reg) ttbr0) };
+
+    println!("User ptr: {:p}", user_region);
+    // TODO: sometimes get an insn abort here? (leads to UART deadlock)
+    println!(
+        "Physical addr: {:?}",
+        memory::physical_addr(user_region.addr())
+    );
+    let access = crate::arch::memory::at_s1e0r(user_region.addr());
+    println!(
+        "user access: {:?}",
+        access.map(|b| b.bits()).map_err(|e| e.bits())
+    );
+
+    let start = sync::get_time();
+    {
+        let code_start = (&raw const user_code_start).cast::<u32>();
+        let code_end = (&raw const user_code_end).cast::<u32>();
+        let len = unsafe { code_end.offset_from(code_start) }
+            .try_into()
+            .unwrap();
+        let code_src = unsafe { core::slice::from_raw_parts(code_start, len) };
+
+        let user_code_ptr = user_region.cast::<u32>();
+        let user_code = unsafe { core::slice::from_raw_parts_mut(user_code_ptr, code_src.len()) };
+        user_code.copy_from_slice(code_src);
+    }
+    let end = sync::get_time();
+
+    // TODO: this sometimes takes significantly longer?
+    // "Done copying user data, took 868749µs"
+    println!("Done copying user data, took {:4}µs", end - start);
+
+    let user_sp = 0x100_0000;
+    let user_entry = 0x20_0000;
+
+    let user_thread = unsafe { thread::Thread::new_user(user_sp, user_entry, ttbr0) };
+
+    event::SCHEDULER.add_task(event::Event::ScheduleThread(user_thread));
+
+    thread::stop();
+}

--- a/crates/kernel/src/arch/aarch64/boot.rs
+++ b/crates/kernel/src/arch/aarch64/boot.rs
@@ -87,19 +87,22 @@ drop_to_el1:
     mov x5, #(1 << 31)
     // orr x5, x5, #0x38
     msr hcr_el2, x5
+
     ldr x5, ={SCTLR_EL1}
     msr SCTLR_EL1, x5
     ldr x5, ={TCR_EL1}
     msr TCR_EL1, x5
     adr x5, KERNEL_TRANSLATION_TABLE
     msr TTBR1_EL1, x5
+    ldr x5, =0b010001000000000011111111 // Entry 0 is normal memory, entry 1 is device memory, 2 = normal noncacheable memory
+    msr MAIR_EL1, x5
+
     mov x5, #0b0101
     msr SPSR_EL2, x5
+
     ldr x5, =0xFFFFFFFFFE000000 // TODO: slightly cleaner way of encoding this?
     orr lr, lr, x5
     msr ELR_EL2, lr
-    ldr x5, =0b010001000000000011111111 // Entry 0 is normal memory, entry 1 is device memory, 2 = normal noncacheable memory
-    msr MAIR_EL1, x5
     isb
     eret
 

--- a/crates/kernel/src/arch/aarch64/memory/mod.rs
+++ b/crates/kernel/src/arch/aarch64/memory/mod.rs
@@ -6,6 +6,9 @@ use core::arch::asm;
 use machine::{at_s1e1r, LeafDescriptor};
 pub use vmm::{map_device, map_physical, map_physical_noncacheable};
 
+pub use machine::at_s1e0r;
+pub use vmm::create_user_region;
+
 pub const INIT_TCR_EL1: u64 = machine::TcrEl1::default().bits();
 pub const INIT_TRANSLATION: u64 = LeafDescriptor::new(0)
     .set_global()

--- a/crates/kernel/src/exceptions.rs
+++ b/crates/kernel/src/exceptions.rs
@@ -189,6 +189,10 @@ unsafe extern "C" fn exception_handler_example(
                     ctx.regs[0] = ctx.regs[0] * ctx.regs[1];
                     return ctx;
                 }
+                2 => {
+                    println!("Got syscall #2!  Shutting down");
+                    crate::shutdown();
+                }
                 _ => {
                     println!("Unknown syscall number {arg:#x}");
                     halt()

--- a/crates/kernel/src/exceptions.rs
+++ b/crates/kernel/src/exceptions.rs
@@ -83,7 +83,7 @@ __exception_vector_start:
 .org 0x380
     save_context exception_handler_unhandled, 7
 
-// Lower exception level, Aarch32
+// Lower exception level, Aarch64
 .org 0x400
     save_context exception_handler_unhandled, 8
 .org 0x480
@@ -93,7 +93,7 @@ __exception_vector_start:
 .org 0x580
     save_context exception_handler_unhandled, 11
 
-// Lower exception level, Aarch64
+// Lower exception level, Aarch32
 .org 0x600
     save_context exception_handler_unhandled, 12
 .org 0x680
@@ -160,11 +160,11 @@ unsafe extern "C" fn exception_handler_example(
     // far_el1 should be preserved up to this point
     // TODO: need to ensure that LLVM doesn't reorder this load
     // after an operation that could overwrite it (yield-like ops)
-    let far_el1: usize;
+    let far: usize;
     unsafe {
         asm! {
             "mrs {}, far_el1",
-            out(reg) far_el1,
+            out(reg) far,
             options(nomem, nostack, preserves_flags)
         }
     }
@@ -176,8 +176,7 @@ unsafe extern "C" fn exception_handler_example(
     let _insn_len = if ((esr >> 25) & 1) != 0 { 4 } else { 2 };
 
     if uart::UART.is_initialized() {
-        println!("Received exception: elr={elr:#x} spsr={spsr:#010x} esr={esr:#010x} (class {exception_class:#x} / {class_name}) {arg}");
-        println!("(Faulting address, if relevant: 0x{far_el1:X})");
+        println!("Received exception: elr={elr:#x} spsr={spsr:#010x} esr={esr:#010x} far={far:#010x} (class {exception_class:#x} / {class_name}) {arg}");
     }
 
     match exception_class {

--- a/crates/kernel/src/exceptions.rs
+++ b/crates/kernel/src/exceptions.rs
@@ -85,9 +85,9 @@ __exception_vector_start:
 
 // Lower exception level, Aarch64
 .org 0x400
-    save_context exception_handler_unhandled, 8
+    save_context exception_handler_example, 8
 .org 0x480
-    save_context exception_handler_unhandled, 9
+    save_context exception_handler_irq, 9
 .org 0x500
     save_context exception_handler_unhandled, 10
 .org 0x580


### PR DESCRIPTION
Building off of #9, this creates a statically mapped region of virtual memory for a user process, loads some code into it, and creates a user thread that runs that code at EL0.  This just directly loads in assembly instructions to test usermode; a proper init binary and ELF loader are implemented in #10.