### PR TITLE
Update codebase to run for Raspi 4b 

### DIFF
--- a/crates/kernel/scripts/run-rpi3b.sh
+++ b/crates/kernel/scripts/run-rpi3b.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+set -ex
+QEMU_TARGET_HARDWARE="-M raspi3b -dtb bcm2710-rpi-3-b-plus.dtb" $(dirname "$0")/run.sh

--- a/crates/kernel/scripts/run.sh
+++ b/crates/kernel/scripts/run.sh
@@ -2,6 +2,7 @@
 
 set -e
 
+QEMU_TARGET_HARDWARE=${QEMU_TARGET_HARDWARE-"-M raspi4b -dtb bcm2711-rpi-4-b.dtb"}
 QEMU_DEBUG=${QEMU_DEBUG-"mmu,guest_errors"}
 QEMU_DISPLAY=${QEMU_DISPLAY-"-display none"}
 DEBUG_ARGS=${DEBUG_ARGS-"-s"}
@@ -26,7 +27,7 @@ if test "$DEBUG_ARGS" = "-s -S" ; then
 fi
 
 qemu-system-aarch64 \
-    -M raspi3b -dtb bcm2710-rpi-3-b-plus.dtb \
+    ${QEMU_TARGET_HARDWARE} \
     -kernel kernel.bin \
     -serial stdio \
     ${QEMU_DISPLAY} \

--- a/crates/kernel/src/lib.rs
+++ b/crates/kernel/src/lib.rs
@@ -30,6 +30,14 @@ static START_BARRIER: AtomicUsize = AtomicUsize::new(0);
 const FLAG_MULTICORE: bool = true;
 const FLAG_PREEMPTION: bool = true;
 
+pub struct HardwareConfig {
+    cpu_type: &'static [u8],
+}
+
+const HARDWARE_CONFIG: HardwareConfig = HardwareConfig {
+    cpu_type: b"arm,cortex-a72",
+};
+
 extern "Rust" {
     fn kernel_main(device_tree: device_tree::DeviceTree);
 }
@@ -37,7 +45,7 @@ extern "Rust" {
 pub fn enable_other_cpus(tree: &device_tree::DeviceTree<'_>, start_fn: unsafe extern "C" fn()) {
     use device_tree::format::StructEntry;
     // TODO: proper discovery through the /cpus/cpu@* path, rather than compatible search
-    for mut iter in device::discover_compatible(tree, b"arm,cortex-a53").unwrap() {
+    for mut iter in device::discover_compatible(tree, HARDWARE_CONFIG.cpu_type).unwrap() {
         let mut name = None;
         let mut method = None;
         let mut release_addr = None;


### PR DESCRIPTION
Required version Qemu 9.0 (Available from apt in Ubuntu 24.10, or self-compilation)
