### PR TITLE
Generalize device-tree CPU discovery

### DIFF
--- a/crates/device-tree/src/util.rs
+++ b/crates/device-tree/src/util.rs
@@ -297,7 +297,6 @@ impl<'a> Iterator for MappingIterator<'a> {
                         }
 
                         mapping.mapping = Some(slice);
-                        return self.next();
                     }
                 }
             }

--- a/crates/kernel/examples/vsync.rs
+++ b/crates/kernel/examples/vsync.rs
@@ -4,16 +4,18 @@
 extern crate alloc;
 extern crate kernel;
 
-use device::{find_device_addr, mailbox};
+use device::{discover_compatible, find_device_addr, mailbox};
 use kernel::*;
 
 #[no_mangle]
 extern "Rust" fn kernel_main(tree: device_tree::DeviceTree) {
     println!("| starting kernel_main");
 
-    let (mailbox_addr, _) = find_device_addr(&tree, b"brcm,bcm2835-mbox")
+    let mailbox = discover_compatible(&tree, b"brcm,bcm2835-mbox")
         .unwrap()
+        .next()
         .unwrap();
+    let (mailbox_addr, _) = find_device_addr(mailbox).unwrap().unwrap();
     let mailbox_base = unsafe { memory::map_device(mailbox_addr) }.as_ptr();
     let mut mailbox = unsafe { mailbox::VideoCoreMailbox::init(mailbox_base) };
 

--- a/crates/kernel/src/device.rs
+++ b/crates/kernel/src/device.rs
@@ -65,30 +65,19 @@ pub fn discover_compatible<'a, 'b>(
     })
 }
 
-pub fn find_device_addr(
-    tree: &DeviceTree<'_>,
-    compatible: &[u8],
-) -> Result<Option<(usize, usize)>, &'static str> {
-    let mut result = None;
-    'outer: for mut iter in discover_compatible(tree, compatible)? {
-        while let Some(Ok(entry)) = iter.next() {
-            match entry {
-                StructEntry::Prop { name: "reg", data } => {
-                    let addr_size = iter.parse_addr_size(data)?;
-                    match iter.map_addr_size(addr_size) {
-                        Ok(m) => {
-                            result = Some((m.addr as usize, m.size as usize));
-                            break 'outer;
-                        }
-                        Err(_) => (),
-                    }
-                    break;
-                }
-                _ => (),
+pub fn find_device_addr(iter: MappingIterator) -> Result<Option<(usize, usize)>, &'static str> {
+    let depth = iter.current_depth() + 1;
+    let mut props = iter.into_props_iter(depth);
+    while let Some(Ok((name, data))) = props.next() {
+        if name == "reg" {
+            let addr_size = props.parse_addr_size(data)?;
+            if let Some(m) = props.map_addr_size(addr_size).ok() {
+                return Ok(Some((m.addr as usize, m.size as usize)));
             }
+            break;
         }
     }
-    Ok(result)
+    Ok(None)
 }
 
 pub static WATCHDOG: UnsafeInit<SpinLock<watchdog::bcm2835_wdt_driver>> =
@@ -98,8 +87,10 @@ pub static IRQ_CONTROLLER: UnsafeInit<InterruptSpinLock<timer::bcm2836_l1_intc_d
     unsafe { UnsafeInit::uninit() };
 
 pub fn init_devices(tree: &DeviceTree<'_>) {
+    let mut uarts = discover_compatible(tree, b"arm,pl011").unwrap();
     {
-        let (uart_addr, _) = find_device_addr(tree, b"arm,pl011").unwrap().unwrap();
+        let uart = uarts.next().unwrap();
+        let (uart_addr, _) = find_device_addr(uart).unwrap().unwrap();
         let uart_base = unsafe { map_device(uart_addr) }.as_ptr();
 
         unsafe { uart::UART.init(SpinLock::new(uart::UARTInner::new(uart_base))) };
@@ -107,9 +98,11 @@ pub fn init_devices(tree: &DeviceTree<'_>) {
     }
 
     {
-        let (watchdog_addr, _) = find_device_addr(tree, b"brcm,bcm2835-pm-wdt")
+        let watchdog = discover_compatible(tree, b"brcm,bcm2835-pm-wdt")
             .unwrap()
+            .next()
             .unwrap();
+        let (watchdog_addr, _) = find_device_addr(watchdog).unwrap().unwrap();
         let watchdog_base = unsafe { map_device(watchdog_addr) }.as_ptr();
 
         unsafe {
@@ -122,12 +115,75 @@ pub fn init_devices(tree: &DeviceTree<'_>) {
 
     {
         println!("| initializing interrupt controller");
-        let (intc_addr, _) = find_device_addr(tree, b"brcm,bcm2836-l1-intc")
+        let intc = discover_compatible(tree, b"brcm,bcm2836-l1-intc")
             .unwrap()
+            .next()
             .unwrap();
+        let (intc_addr, _) = find_device_addr(intc).unwrap().unwrap();
         let intc_base = unsafe { map_device(intc_addr) }.as_ptr();
         let intc = timer::bcm2836_l1_intc_driver::new(intc_base);
         let intc = InterruptSpinLock::new(intc);
         unsafe { IRQ_CONTROLLER.init(intc) };
     }
+}
+
+/// Discovers and starts all cores, and returns the number of cores found.
+pub fn enable_cpus(tree: &device_tree::DeviceTree<'_>, start_fn: unsafe extern "C" fn()) -> usize {
+    use crate::memory::map_physical;
+    use device_tree::format::StructEntry;
+    use device_tree::util::find_node;
+
+    let physical_start = crate::memory::physical_addr(start_fn as usize).unwrap();
+
+    let mut core_count = 0;
+
+    let mut iter = find_node(tree, "/cpus").unwrap().unwrap();
+    iter.next(); // skip the BeginNode for "cpus" itself
+
+    while let Some(Ok(entry)) = iter.next() {
+        let StructEntry::BeginNode { name } = entry else {
+            // skip inline properties
+            continue;
+        };
+
+        let depth = iter.current_depth();
+        let mut props = iter.into_props_iter(depth);
+
+        let mut device_type = None;
+        let mut method = None;
+        let mut release_addr = None;
+        while let Some(Ok((name, data))) = props.next() {
+            match name {
+                "device_type" => device_type = Some(data),
+                "enable-method" => method = Some(data),
+                "cpu-release-addr" => {
+                    let addr: endian::u64_be = bytemuck::pod_read_unaligned(data);
+                    release_addr = Some(addr.get() as usize);
+                }
+                _ => (),
+            }
+        }
+
+        iter = props.into();
+
+        match (device_type, method, release_addr) {
+            (Some(b"cpu\0"), Some(b"spin-table\0"), Some(release_addr)) => {
+                println!("| Waking cpu {:?}", name);
+
+                let start = unsafe { map_physical(release_addr, 8).cast::<u64>() };
+                unsafe { core::ptr::write_volatile(start.as_ptr(), physical_start) };
+
+                core_count += 1;
+            }
+            (Some(b"cpu\0"), ..) => println!("| Could not wake cpu {:?}", name),
+            _ => (),
+        }
+    }
+
+    println!("| discovered {core_count} cores");
+    println!("| started cores, waiting for init.");
+
+    unsafe { crate::arch::sev() };
+
+    core_count
 }


### PR DESCRIPTION
This generalizes the CPU discovery approach; it should detect all CPUs on both rpi3b and rpi4b (as well as most arm systems).  It now only waits for the CPUs that it discovered, rather than assuming 4 CPUs and hanging if it failed to discover/wake all of them.