### PR TITLE
Add basic support for the Pi's secondary UART (bcm2835-aux mini-uart)

### DIFF
--- a/crates/device-tree/src/util.rs
+++ b/crates/device-tree/src/util.rs
@@ -297,7 +297,6 @@ impl<'a> Iterator for MappingIterator<'a> {
                         }
 
                         mapping.mapping = Some(slice);
-                        return self.next();
                     }
                 }
             }

--- a/crates/kernel/examples/vsync.rs
+++ b/crates/kernel/examples/vsync.rs
@@ -4,16 +4,18 @@
 extern crate alloc;
 extern crate kernel;
 
-use device::{find_device_addr, mailbox};
+use device::{discover_compatible, find_device_addr, mailbox};
 use kernel::*;
 
 #[no_mangle]
 extern "Rust" fn kernel_main(tree: device_tree::DeviceTree) {
     println!("| starting kernel_main");
 
-    let (mailbox_addr, _) = find_device_addr(&tree, b"brcm,bcm2835-mbox")
+    let mailbox = discover_compatible(&tree, b"brcm,bcm2835-mbox")
         .unwrap()
+        .next()
         .unwrap();
+    let (mailbox_addr, _) = find_device_addr(mailbox).unwrap().unwrap();
     let mailbox_base = unsafe { memory::map_device(mailbox_addr) }.as_ptr();
     let mut mailbox = unsafe { mailbox::VideoCoreMailbox::init(mailbox_base) };
 

--- a/crates/kernel/scripts/run.sh
+++ b/crates/kernel/scripts/run.sh
@@ -26,10 +26,19 @@ if test "$DEBUG_ARGS" = "-s -S" ; then
     echo 'gdb kernel.elf -ex "target remote localhost:1234"'
 fi
 
+# TODO: qemu's pipe handling drops characters, doesn't flush
+UART_PIPE="uart2"
+if test ! -p "$UART_PIPE" ; then
+    mkfifo "$UART_PIPE"
+fi
+SERIAL_ALT="pipe:$UART_PIPE"
+# SERIAL_ALT="tcp:127.0.0.1:5377" # listen with nc -kl 5377
+
 qemu-system-aarch64 \
     ${QEMU_TARGET_HARDWARE} \
     -kernel kernel.bin \
     -serial stdio \
+    ${UART_PIPE} \
     ${QEMU_DISPLAY} \
     ${QEMU_DEBUG_PFX} ${QEMU_DEBUG} \
     ${DEBUG_ARGS}

--- a/crates/kernel/src/device.rs
+++ b/crates/kernel/src/device.rs
@@ -65,30 +65,19 @@ pub fn discover_compatible<'a, 'b>(
     })
 }
 
-pub fn find_device_addr(
-    tree: &DeviceTree<'_>,
-    compatible: &[u8],
-) -> Result<Option<(usize, usize)>, &'static str> {
-    let mut result = None;
-    'outer: for mut iter in discover_compatible(tree, compatible)? {
-        while let Some(Ok(entry)) = iter.next() {
-            match entry {
-                StructEntry::Prop { name: "reg", data } => {
-                    let addr_size = iter.parse_addr_size(data)?;
-                    match iter.map_addr_size(addr_size) {
-                        Ok(m) => {
-                            result = Some((m.addr as usize, m.size as usize));
-                            break 'outer;
-                        }
-                        Err(_) => (),
-                    }
-                    break;
-                }
-                _ => (),
+pub fn find_device_addr(iter: MappingIterator) -> Result<Option<(usize, usize)>, &'static str> {
+    let depth = iter.current_depth() + 1;
+    let mut props = iter.into_props_iter(depth);
+    while let Some(Ok((name, data))) = props.next() {
+        if name == "reg" {
+            let addr_size = props.parse_addr_size(data)?;
+            if let Some(m) = props.map_addr_size(addr_size).ok() {
+                return Ok(Some((m.addr as usize, m.size as usize)));
             }
+            break;
         }
     }
-    Ok(result)
+    Ok(None)
 }
 
 pub static WATCHDOG: UnsafeInit<SpinLock<watchdog::bcm2835_wdt_driver>> =
@@ -98,8 +87,10 @@ pub static IRQ_CONTROLLER: UnsafeInit<InterruptSpinLock<timer::bcm2836_l1_intc_d
     unsafe { UnsafeInit::uninit() };
 
 pub fn init_devices(tree: &DeviceTree<'_>) {
+    let mut uarts = discover_compatible(tree, b"arm,pl011").unwrap();
     {
-        let (uart_addr, _) = find_device_addr(tree, b"arm,pl011").unwrap().unwrap();
+        let uart = uarts.next().unwrap();
+        let (uart_addr, _) = find_device_addr(uart).unwrap().unwrap();
         let uart_base = unsafe { map_device(uart_addr) }.as_ptr();
 
         unsafe { uart::UART.init(SpinLock::new(uart::UARTInner::new(uart_base))) };
@@ -107,9 +98,11 @@ pub fn init_devices(tree: &DeviceTree<'_>) {
     }
 
     {
-        let (watchdog_addr, _) = find_device_addr(tree, b"brcm,bcm2835-pm-wdt")
+        let watchdog = discover_compatible(tree, b"brcm,bcm2835-pm-wdt")
             .unwrap()
+            .next()
             .unwrap();
+        let (watchdog_addr, _) = find_device_addr(watchdog).unwrap().unwrap();
         let watchdog_base = unsafe { map_device(watchdog_addr) }.as_ptr();
 
         unsafe {
@@ -122,12 +115,75 @@ pub fn init_devices(tree: &DeviceTree<'_>) {
 
     {
         println!("| initializing interrupt controller");
-        let (intc_addr, _) = find_device_addr(tree, b"brcm,bcm2836-l1-intc")
+        let intc = discover_compatible(tree, b"brcm,bcm2836-l1-intc")
             .unwrap()
+            .next()
             .unwrap();
+        let (intc_addr, _) = find_device_addr(intc).unwrap().unwrap();
         let intc_base = unsafe { map_device(intc_addr) }.as_ptr();
         let intc = timer::bcm2836_l1_intc_driver::new(intc_base);
         let intc = InterruptSpinLock::new(intc);
         unsafe { IRQ_CONTROLLER.init(intc) };
     }
+}
+
+/// Discovers and starts all cores, and returns the number of cores found.
+pub fn enable_cpus(tree: &device_tree::DeviceTree<'_>, start_fn: unsafe extern "C" fn()) -> usize {
+    use crate::memory::map_physical;
+    use device_tree::format::StructEntry;
+    use device_tree::util::find_node;
+
+    let physical_start = crate::memory::physical_addr(start_fn as usize).unwrap();
+
+    let mut core_count = 0;
+
+    let mut iter = find_node(tree, "/cpus").unwrap().unwrap();
+    iter.next(); // skip the BeginNode for "cpus" itself
+
+    while let Some(Ok(entry)) = iter.next() {
+        let StructEntry::BeginNode { name } = entry else {
+            // skip inline properties
+            continue;
+        };
+
+        let depth = iter.current_depth();
+        let mut props = iter.into_props_iter(depth);
+
+        let mut device_type = None;
+        let mut method = None;
+        let mut release_addr = None;
+        while let Some(Ok((name, data))) = props.next() {
+            match name {
+                "device_type" => device_type = Some(data),
+                "enable-method" => method = Some(data),
+                "cpu-release-addr" => {
+                    let addr: endian::u64_be = bytemuck::pod_read_unaligned(data);
+                    release_addr = Some(addr.get() as usize);
+                }
+                _ => (),
+            }
+        }
+
+        iter = props.into();
+
+        match (device_type, method, release_addr) {
+            (Some(b"cpu\0"), Some(b"spin-table\0"), Some(release_addr)) => {
+                println!("| Waking cpu {:?}", name);
+
+                let start = unsafe { map_physical(release_addr, 8).cast::<u64>() };
+                unsafe { core::ptr::write_volatile(start.as_ptr(), physical_start) };
+
+                core_count += 1;
+            }
+            (Some(b"cpu\0"), ..) => println!("| Could not wake cpu {:?}", name),
+            _ => (),
+        }
+    }
+
+    println!("| discovered {core_count} cores");
+    println!("| started cores, waiting for init.");
+
+    unsafe { crate::arch::sev() };
+
+    core_count
 }

--- a/crates/kernel/src/device/bcm2835_aux.rs
+++ b/crates/kernel/src/device/bcm2835_aux.rs
@@ -1,0 +1,111 @@
+use crate::sync::{SpinLock, Volatile};
+
+// https://www.raspberrypi.org/app/uploads/2012/02/BCM2835-ARM-Peripherals.pdf
+
+pub struct MiniUart {
+    base: *mut (),
+}
+
+#[allow(dead_code)]
+#[rustfmt::skip]
+impl MiniUart {
+    const AUX_IRQ: usize = 0x0000;            // Auxiliary Interrupt status 3
+    const AUX_ENABLES: usize = 0x0004;        // Auxiliary enables 3
+    const AUX_MU_IO_REG: usize = 0x0040;      // Mini Uart I/O Data 8
+    const AUX_MU_IER_REG: usize = 0x0044;     // Mini Uart Interrupt Enable 8
+    const AUX_MU_IIR_REG: usize = 0x0048;     // Mini Uart Interrupt Identify 8
+    const AUX_MU_LCR_REG: usize = 0x004C;     // Mini Uart Line Control 8
+    const AUX_MU_MCR_REG: usize = 0x0050;     // Mini Uart Modem Control 8
+    const AUX_MU_LSR_REG: usize = 0x0054;     // Mini Uart Line Status 8
+    const AUX_MU_MSR_REG: usize = 0x0058;     // Mini Uart Modem Status 8
+    const AUX_MU_SCRATCH: usize = 0x005C;     // Mini Uart Scratch 8
+    const AUX_MU_CNTL_REG: usize = 0x0060;    // Mini Uart Extra Control 8
+    const AUX_MU_STAT_REG: usize = 0x0064;    // Mini Uart Extra Status 32
+    const AUX_MU_BAUD_REG: usize = 0x0068;    // Mini Uart Baudrate 16
+    const AUX_SPI0_CNTL0_REG: usize = 0x0080; // SPI 1 Control register 0 32
+    const AUX_SPI0_CNTL1_REG: usize = 0x0084; // SPI 1 Control register 1 8
+    const AUX_SPI0_STAT_REG: usize = 0x0088;  // SPI 1 Status 32
+    const AUX_SPI0_IO_REG: usize = 0x0090;    // SPI 1 Data 32
+    const AUX_SPI0_PEEK_REG: usize = 0x0094;  // SPI 1 Peek 16
+    const AUX_SPI1_CNTL0_REG: usize = 0x00C0; // SPI 2 Control register 0 32
+    const AUX_SPI1_CNTL1_REG: usize = 0x00C4; // SPI 2 Control register 1 8
+    const AUX_SPI1_STAT_REG: usize = 0x00C8;  // SPI 2 Status 32
+    const AUX_SPI1_IO_REG: usize = 0x00D0;    // SPI 2 Data 32
+    const AUX_SPI1_PEEK_REG: usize = 0x00D4;  // SPI 2 Peek 16
+}
+
+impl MiniUart {
+    pub unsafe fn new(base: *mut ()) -> Self {
+        // TODO[hardware]: proper mini UART initialization
+        // (this is enough to convince qemu that it's initialized)
+        let this = Self { base };
+        unsafe {
+            // Enable mini UART, disable both SPI modules
+            this.reg(Self::AUX_ENABLES).write(0b001);
+            // Clear bit 7, DLAB (baudrate register access instead of data)
+            // Clear bit 6, break
+            // Set bit 0, 8-bit mode
+            this.reg(Self::AUX_MU_LCR_REG)
+                .write((0 << 7) | (0 << 6) | (1 << 0));
+
+            // TODO: initialize GPIO
+        }
+        this
+    }
+
+    fn reg(&self, reg: usize) -> Volatile<u32> {
+        Volatile(self.base.wrapping_byte_add(reg).cast::<u32>())
+    }
+    unsafe fn transmit_fifo_full(&self) -> bool {
+        (unsafe { self.reg(Self::AUX_MU_LSR_REG).read() } & (1 << 5)) == 0
+    }
+    unsafe fn receive_fifo_empty(&self) -> bool {
+        (unsafe { self.reg(Self::AUX_MU_LSR_REG).read() } & 0b1) == 0
+    }
+    pub fn writec(&mut self, c: u8) {
+        unsafe {
+            while self.transmit_fifo_full() {}
+            self.reg(Self::AUX_MU_IO_REG).write(c as u32);
+        }
+    }
+    pub fn getc(&mut self) -> u8 {
+        unsafe {
+            while self.receive_fifo_empty() {}
+            self.reg(Self::AUX_MU_IO_REG).read() as u8
+        }
+    }
+    pub fn try_getc(&mut self) -> Option<u8> {
+        unsafe {
+            if self.receive_fifo_empty() {
+                None
+            } else {
+                Some(self.reg(Self::AUX_MU_IO_REG).read() as u8)
+            }
+        }
+    }
+}
+
+unsafe impl Send for MiniUart {}
+
+impl core::fmt::Write for MiniUart {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        for b in s.bytes() {
+            self.writec(b);
+        }
+        Ok(())
+    }
+}
+
+impl core::fmt::Write for &SpinLock<MiniUart> {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        let mut inner = self.lock();
+        for b in s.bytes() {
+            inner.writec(b);
+        }
+        Ok(())
+    }
+    fn write_fmt(&mut self, args: core::fmt::Arguments<'_>) -> core::fmt::Result {
+        let mut inner = self.lock();
+        inner.write_fmt(args)
+    }
+}

--- a/crates/kernel/src/device/uart.rs
+++ b/crates/kernel/src/device/uart.rs
@@ -1,5 +1,7 @@
 use crate::sync::{SpinLock, UnsafeInit, Volatile};
 
+// https://documentation-service.arm.com/static/5e8e36c2fd977155116a90b5
+
 pub static UART: UnsafeInit<SpinLock<UARTInner>> = unsafe { UnsafeInit::uninit() };
 
 pub struct UARTInner {


### PR DESCRIPTION
Like the PL011 UART implementation, this is still missing the proper GPIO initialization (as well as other initialization steps), but it works on QEMU.

It currently creates and connects to a named pipe `uart2` in the same directory as the kernel image.  This works, but QEMU often drops the bytes at the start and end of the message, and sometimes does not flush its internal buffer before exiting.  The TCP/unix socket modes should be more reliable, but will require more set-up work.