### PR TITLE
Implement basic LZ4 compression

### DIFF
--- a/crates/lz4/src/bin/cli.rs
+++ b/crates/lz4/src/bin/cli.rs
@@ -1,0 +1,29 @@
+use std::io::Write;
+
+use lz4::frame::FrameOptions;
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let input_path = args.next().unwrap();
+    let output_path = args.next().unwrap();
+
+    let input = std::fs::read(input_path).unwrap();
+
+    let frame = FrameOptions {
+        block_indep: true,
+        block_checksum: true,
+        content_checksum: true,
+        content_size: lz4::frame::ContentSize::Known(input.len() as u64),
+        max_block_size: lz4::frame::MaxBlockSize::Size4MiB,
+    };
+
+    let mut output = vec![0; frame.max_compressed_size(input.len())];
+    let compressed = lz4::compress_into(&frame, &input, &mut output).unwrap();
+
+    let mut check = vec![0; input.len()];
+    let data = lz4::decode_into(compressed, &mut check).unwrap();
+    assert!(input == data);
+
+    let mut file = std::fs::File::create_new(output_path).unwrap();
+    file.write_all(compressed).unwrap();
+}

--- a/crates/lz4/src/compress.rs
+++ b/crates/lz4/src/compress.rs
@@ -1,0 +1,198 @@
+const TABLE_SIZE: usize = 4096;
+
+struct MatchTable {
+    table: [(u32, u32); TABLE_SIZE],
+}
+
+fn hash(pat: u32) -> usize {
+    ((pat.wrapping_mul(0xB7D5C82D) >> 16) % TABLE_SIZE as u32) as usize
+}
+
+impl MatchTable {
+    fn new() -> Self {
+        MatchTable {
+            table: [(0, 0xFFFFFFFF); TABLE_SIZE],
+        }
+    }
+    fn get(&self, pattern: u32) -> Option<u32> {
+        let (pat, base) = self.table[hash(pattern)];
+        (pat == pattern && base != 0xFFFFFFFF).then_some(base)
+    }
+    fn insert(&mut self, pattern: u32, base: u32) {
+        self.table[hash(pattern)] = (pattern, base);
+    }
+}
+
+pub fn compress_block(input: &[u8], output: &mut [u8]) -> Option<usize> {
+    let mut idx = 0;
+    let mut last_idx = 0;
+    let mut cursor = 0;
+    let mut table = MatchTable::new();
+
+    // Potential speed-up options:
+    // - change step size by miss count (lz4_flex steps by floor(misses/32) + 1)
+    // - hash by more of the input (on 64 bit, lz4_flex hashes 40 bits (from a 64 bit read))
+    // - better hash function?
+    // - don't load pattern values into the hash table; just check them
+    //   directly from the input
+
+    let input_end = input.len().saturating_sub(12);
+    while idx < input_end {
+        let pat = u32::from_le_bytes(input[idx..][..4].try_into().unwrap());
+        let found = table.get(pat);
+        table.insert(pat, idx as u32);
+
+        if let Some(base) = found.map(|b| b as usize) {
+            if base < idx && idx - base <= u16::MAX as usize {
+                let off = (idx - base) as u16;
+
+                let max_backtrack = (idx - last_idx).min(base);
+                let backtrack = (1..=max_backtrack)
+                    .find(|i| input[base - i] != input[idx - i])
+                    .map(|b| b - 1)
+                    .unwrap_or(max_backtrack);
+
+                let input_match_end = input.len().saturating_sub(5);
+
+                let match_src = &input[base..idx];
+                let target = &input[idx..input_match_end];
+                let min_match_len = 4;
+                let match_len = (min_match_len..target.len())
+                    .find(|&i| match_src[i % match_src.len()] != target[i])
+                    .unwrap_or(target.len());
+
+                // Not required, but this can improve compression in many cases
+                if match_len < 5 {
+                    continue;
+                }
+
+                if backtrack > 0 {
+                    let literal = &input[last_idx..idx - backtrack];
+                    let match_len = match_len + backtrack;
+                    cursor += emit_block(&mut output[cursor..], literal, match_len, off)?;
+                } else {
+                    let literal = &input[last_idx..idx];
+                    cursor += emit_block(&mut output[cursor..], literal, match_len, off)?;
+                }
+
+                idx += match_len;
+                last_idx = idx;
+
+                // Semi-arbitrary offset of 2, used by the reference impl
+                // idx is at least 5 bytes from the end of input due to input_match_end
+                // let pat = u32::from_le_bytes(input[idx - 2..][..4].try_into().unwrap());
+                // table.insert(pat, (idx - 2) as u32);
+                continue;
+            }
+        }
+        idx += 1;
+    }
+
+    let literal = &input[last_idx..input.len()];
+    cursor += emit_end_block(&mut output[cursor..], literal)?;
+    Some(cursor)
+}
+
+fn emit_block(output: &mut [u8], literal: &[u8], match_len: usize, offset: u16) -> Option<usize> {
+    let literal_len = literal.len();
+    let match_len = match_len - 4;
+
+    let literal_div = (literal_len.saturating_sub(15)) / 255;
+    let literal_mod = (literal_len.saturating_sub(15)) % 255;
+    let match_div = (match_len.saturating_sub(15)) / 255;
+    let match_mod = (match_len.saturating_sub(15)) % 255;
+
+    let start = 0;
+    let lit_len_start = start + 1;
+    let lit_start = lit_len_start + ((literal_len >= 15) as usize + literal_div);
+    let off_start = lit_start + literal_len;
+    let match_len_start = off_start + 2;
+    let end = match_len_start + ((match_len >= 15) as usize + match_div);
+
+    if output.len() < end {
+        return None;
+    }
+
+    let token = ((literal_len.min(15) << 4) | match_len.min(15)) as u8;
+    output[start] = token;
+
+    if literal_len >= 15 {
+        output[lit_len_start..lit_start - 1].fill(255);
+        output[lit_start - 1] = literal_mod as u8;
+    }
+
+    output[lit_start..off_start].copy_from_slice(literal);
+
+    output[off_start..match_len_start].copy_from_slice(&u16::to_le_bytes(offset));
+
+    if match_len >= 15 {
+        output[match_len_start..end - 1].fill(255);
+        output[end - 1] = match_mod as u8;
+    }
+
+    Some(end)
+}
+
+fn emit_end_block(output: &mut [u8], literal: &[u8]) -> Option<usize> {
+    let literal_len = literal.len();
+    let literal_div = (literal_len.saturating_sub(15)) / 255;
+    let literal_mod = (literal_len.saturating_sub(15)) % 255;
+
+    let start = 0;
+    let lit_len_start = start + 1;
+    let lit_start = lit_len_start + ((literal_len >= 15) as usize + literal_div);
+    let end = lit_start + literal_len;
+
+    if output.len() < end {
+        return None;
+    }
+
+    let token = ((literal_len.min(15) << 4) | 0) as u8;
+    output[start] = token;
+
+    if literal_len >= 15 {
+        output[lit_len_start..lit_start - 1].fill(255);
+        output[lit_start - 1] = literal_mod as u8;
+    }
+
+    output[lit_start..end].copy_from_slice(literal);
+
+    Some(end)
+}
+
+#[test]
+fn test_compress_ratio() {
+    extern crate std;
+    let data = include_bytes!("../Cargo.toml");
+    let mut output = std::vec![0; data.len()];
+
+    let len = compress_block(data, &mut output).unwrap();
+    let slice = &output[..len];
+
+    std::println!("Input len: {}, output len: {}", data.len(), len);
+
+    let mut decompressed = std::vec![0; data.len()];
+    let decomp_len = crate::block::decode_block(slice, &mut decompressed, 0).unwrap();
+    let decomp_slice = &decompressed[..decomp_len];
+
+    assert!(data == decomp_slice);
+}
+
+#[test]
+fn test_compress2() {
+    extern crate std;
+    let mut output = std::vec![0; 1 << 12];
+    let data = [1, 0, 0, 1, 0, 0, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2];
+
+    let len = compress_block(&data, &mut output).unwrap();
+    let slice = &output[..len];
+
+    std::println!("Input len: {}, output len: {}", data.len(), len);
+    std::println!("data: {:?}", slice);
+
+    let mut decompressed = std::vec![0; data.len()];
+    let decomp_len = crate::block::decode_block(slice, &mut decompressed, 0).unwrap();
+    let decomp_slice = &decompressed[..decomp_len];
+
+    assert_eq!(data, decomp_slice);
+}

--- a/crates/lz4/src/frame.rs
+++ b/crates/lz4/src/frame.rs
@@ -10,6 +10,52 @@ pub enum ValidateMode {
     None,
 }
 
+pub struct FrameOptions {
+    pub block_indep: bool,
+    pub block_checksum: bool,
+    pub content_checksum: bool,
+    pub content_size: ContentSize,
+    pub max_block_size: MaxBlockSize,
+}
+
+impl FrameOptions {
+    pub fn max_compressed_size(&self, data_len: usize) -> usize {
+        let has_content_size = !matches!(self.content_size, ContentSize::None);
+        let has_dict_id = false;
+        let header_size = 7 + (has_content_size as usize * 8) + (has_dict_id as usize * 4);
+
+        let max_num_blocks = data_len.div_ceil(self.max_block_size.size());
+        let block_meta = max_num_blocks * (4 + (self.block_checksum as usize) * 4);
+        let trailer = 4 + (self.content_checksum as usize) * 4;
+
+        data_len + header_size + block_meta + trailer
+    }
+}
+
+pub enum ContentSize {
+    None,
+    Detect,
+    Known(u64),
+}
+
+pub enum MaxBlockSize {
+    Size64KiB,
+    Size256KiB,
+    Size1MiB,
+    Size4MiB,
+}
+
+impl MaxBlockSize {
+    pub fn size(&self) -> usize {
+        match self {
+            MaxBlockSize::Size64KiB => 1 << 16,
+            MaxBlockSize::Size256KiB => 1 << 18,
+            MaxBlockSize::Size1MiB => 1 << 20,
+            MaxBlockSize::Size4MiB => 1 << 22,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct FrameHeader {
     magic: [u8; 4],
@@ -19,7 +65,36 @@ pub struct FrameHeader {
     dict_id: Option<u32>,
     checksum: u8,
 }
+
 impl FrameHeader {
+    pub fn new(opt: &FrameOptions) -> Self {
+        let has_content_size = !matches!(opt.content_size, ContentSize::None);
+        let has_dict = false;
+        let block_size_idx = match opt.max_block_size {
+            MaxBlockSize::Size64KiB => 0b100,
+            MaxBlockSize::Size256KiB => 0b101,
+            MaxBlockSize::Size1MiB => 0b110,
+            MaxBlockSize::Size4MiB => 0b111,
+        };
+        FrameHeader {
+            magic: super::frame::LZ4_MAGIC,
+            flag: (0b01 << 6)
+                | ((opt.block_indep as u8) << 5)
+                | ((opt.block_checksum as u8) << 4)
+                | ((has_content_size as u8) << 3)
+                | ((opt.content_checksum as u8) << 2)
+                | (0 << 1)
+                | (has_dict as u8),
+            bd: (block_size_idx << 4),
+            content_size: match opt.content_size {
+                ContentSize::Known(s) => Some(s),
+                _ => None,
+            },
+            dict_id: None,
+            checksum: 0,
+        }
+    }
+
     pub fn flag_version(&self) -> u8 {
         self.flag >> 6
     }
@@ -82,6 +157,16 @@ fn read_le_u32(input: &[u8]) -> Option<(u32, &[u8])> {
 fn read_le_u64(input: &[u8]) -> Option<(u64, &[u8])> {
     let (val, input) = input.split_first_chunk()?;
     Some((u64::from_le_bytes(*val), input))
+}
+fn write_le_u32(out: &mut [u8], value: u32) -> Option<&mut [u8]> {
+    let (val, out) = out.split_first_chunk_mut::<4>()?;
+    val.copy_from_slice(&u32::to_le_bytes(value));
+    Some(out)
+}
+fn write_le_u64(out: &mut [u8], value: u64) -> Option<&mut [u8]> {
+    let (val, out) = out.split_first_chunk_mut::<8>()?;
+    val.copy_from_slice(&u64::to_le_bytes(value));
+    Some(out)
 }
 
 pub fn read_frame(data: &[u8]) -> Result<(FrameHeader, &[u8]), Lz4Error> {
@@ -204,6 +289,99 @@ pub fn decode_frames(
 
     if !input.is_empty() {
         // TODO: handle trailing content?
+        // not required by the spec, but lz4 treats concatenated
+        // frames as a single compressed file.
+    }
+
+    Ok(cur_idx)
+}
+
+pub fn write_header(data: &mut [u8], header: &FrameHeader) -> Result<usize, ()> {
+    let size = 7 + (header.flag_content_size() as usize * 8) + (header.flag_dict_id() as usize * 4);
+    if data.len() < size {
+        return Err(());
+    }
+    let mut out = &mut *data;
+    out[..4].copy_from_slice(&header.magic);
+    out[4] = header.flag;
+    out[5] = header.bd;
+    out = &mut out[6..];
+
+    if header.flag_content_size() {
+        let size = header.content_size.unwrap_or(0);
+        out = write_le_u64(out, size).unwrap();
+    }
+    if header.flag_dict_id() {
+        let id = header.dict_id.ok_or(())?;
+        out = write_le_u32(out, id).unwrap();
+    }
+    let _ = out;
+
+    let hash = xxh32(0, &data[4..size - 1]);
+    data[size - 1] = ((hash >> 8) & 0xFF) as u8;
+
+    Ok(size)
+}
+
+// TODO: streaming compression, rather than in-place
+pub fn encode_frames(
+    header: &FrameOptions,
+    mut input: &[u8],
+    output: &mut [u8],
+    mut cur_idx: usize,
+) -> Result<usize, ()> {
+    let block_checksum = header.block_checksum;
+    let content_checksum = header.content_checksum;
+    let mut hasher = crate::xxh::XXH32Hasher::init(0);
+
+    while !input.is_empty() {
+        // block header (to fill in later)
+        let header_idx = cur_idx;
+        write_le_u32(&mut output[header_idx..], 0x0000_0000).ok_or(())?;
+        cur_idx += 4;
+
+        let block_size = header.max_block_size.size();
+        let input_part = &input[..block_size.min(input.len())];
+        let output_range = output[cur_idx..].get_mut(..input_part.len()).ok_or(())?;
+        let size = crate::compress::compress_block(input_part, output_range);
+
+        let header;
+        match size {
+            Some(size) => {
+                header = size as u32;
+                cur_idx += size;
+            }
+            None => {
+                // Not enough space to compress; store uncompressed
+                header = input_part.len() as u32 | (1 << 31);
+                output_range.copy_from_slice(input_part);
+                cur_idx += input_part.len();
+            }
+        }
+
+        write_le_u32(&mut output[header_idx..], header).ok_or(())?;
+
+        input = &input[input_part.len()..];
+
+        if content_checksum {
+            hasher.write(input_part);
+        }
+
+        if block_checksum {
+            let checksum = xxh32(0, &output[header_idx + 4..cur_idx]);
+            write_le_u32(&mut output[cur_idx..], checksum).ok_or(())?;
+            cur_idx += 4;
+        }
+    }
+
+    // end marker
+    write_le_u32(&mut output[cur_idx..], 0x0000_0000).ok_or(())?;
+    cur_idx += 4;
+
+    if header.content_checksum {
+        let checksum = hasher.finalize();
+        write_le_u32(&mut output[cur_idx..], checksum).ok_or(())?;
+        cur_idx += 4;
     }
 
     Ok(cur_idx)

--- a/crates/lz4/src/lib.rs
+++ b/crates/lz4/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 
 pub mod block;
+pub mod compress;
 pub mod frame;
 pub mod xxh;
 
@@ -16,4 +17,15 @@ pub fn decode_into<'a>(data: &'_ [u8], buf: &'a mut [u8]) -> Result<&'a [u8], fr
     let validate = frame::ValidateMode::Checksums;
     let length = frame::decode_frames(&hdr, data, buf, 0, validate)?;
     Ok(&buf[..length])
+}
+
+pub fn compress_into<'a>(
+    frame: &frame::FrameOptions,
+    data: &'_ [u8],
+    buf: &'a mut [u8],
+) -> Result<&'a [u8], ()> {
+    let header = frame::FrameHeader::new(frame);
+    let off = frame::write_header(buf, &header)?;
+    let off = frame::encode_frames(frame, data, buf, off)?;
+    Ok(&buf[..off])
 }


### PR DESCRIPTION
This implements a simple and relatively fast (linear-time) LZ4 compressor, for use in generating a compressed initial ramdisk. 

It doesn't currently support streaming compression, but that could be added with minor modifications; the compressor would accumulate block_size amounts of input data before emitting compressed blocks.  (If the compressor is configured to output a content size by computing it, the stream must be seekable, to allow the header to be updated when the file is finalized.)  The main reason this was not done in this version is that the compressor would need allocation for the intermediate block storage, and would need a no_std alternative to the Write and Seek traits.