### PR TITLE
Generalize interrupt controller handling to support both rpi3b and rpi4b

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ strip = false
 incremental = false
 debug = 2
 panic = "abort"
+debug-assertions = true
 
 [profile.dev]
 incremental = false

--- a/crates/kernel/examples/timer.rs
+++ b/crates/kernel/examples/timer.rs
@@ -4,9 +4,9 @@
 extern crate alloc;
 extern crate kernel;
 
-use kernel::{context::Context, device::gic::gic_register_isr, *};
+use kernel::*;
 
-fn test_irq_handler(_ctx: &mut Context) {
+fn test_irq_handler(_ctx: &mut context::Context) {
     //Reset the timer to ping again
     device::system_timer::ARM_GENERIC_TIMERS.with_current(|timer| {
         timer.reset_timer();
@@ -29,7 +29,7 @@ extern "Rust" fn kernel_main(_device_tree: device_tree::DeviceTree) {
     let mut iteration = 0;
     let iteration_slice = 0x100000;
 
-    gic_register_isr(30, test_irq_handler);
+    device::gic::GIC.get().register_isr(30, test_irq_handler);
 
     device::system_timer::ARM_GENERIC_TIMERS.with_current(|timer| {
         timer.set_timer_microseconds(0x100000);

--- a/crates/kernel/src/device.rs
+++ b/crates/kernel/src/device.rs
@@ -11,7 +11,6 @@ use device_tree::format::StructEntry;
 use device_tree::util::MappingIterator;
 use device_tree::DeviceTree;
 
-use crate::device::gic::gic_init;
 use crate::memory::{map_device, map_device_block};
 use crate::sync::{InterruptSpinLock, UnsafeInit};
 use crate::SpinLock;
@@ -153,7 +152,7 @@ pub fn init_devices(tree: &DeviceTree<'_>) {
 
         println!("| GIC-400 addr: {:#010x}", gic_addr as usize);
         println!("| GIC-400 base: {:#010x}", gic_base as usize);
-        unsafe { gic_init(gic_base) };
+        unsafe { gic::GIC.init(gic::Gic400Driver::init(gic_base)) };
     }
 
     {

--- a/crates/kernel/src/device/gic.rs
+++ b/crates/kernel/src/device/gic.rs
@@ -106,10 +106,6 @@ const GICC_NSAPR0: usize = 0x00E0; // Non-Secure Active Priority Register (0x0E0
 const GICC_IIDR: usize = 0x00FC; // CPU Interface Identification Register (0x0FC)
 const GICC_DIR: usize = 0x1000; // Deactivate Interrupt Register (0x1000)
 
-/// Register all the IRQ handlers for the GICC here
-pub fn register_gicc_irq_handlers() {
-    super::system_timer::register_arm_generic_timer_irqs();
-}
 pub static GIC: UnsafeInit<Gic400Driver> = unsafe { UnsafeInit::uninit() };
 
 fn isb() {
@@ -124,7 +120,7 @@ pub fn irq_not_handled(_ctx: &mut Context) {
 /// Handles the interrupt and asks handler to handle it
 /// Level-triggered interrupts must be cleared by associaetd irq handler or else it will be called again
 #[no_mangle]
-unsafe extern "C" fn gic_irq_handler(
+pub unsafe extern "C" fn gic_irq_handler(
     ctx: &mut Context,
     _elr: u64,
     _spsr: u64,

--- a/crates/kernel/src/device/timer.rs
+++ b/crates/kernel/src/device/timer.rs
@@ -1,5 +1,18 @@
 #![allow(dead_code)]
 
+// TODO: handle the global interrupt controller on pi3?
+// interrupt-controller@7e00b200
+//   compatible: ["brcm,bcm2836-armctrl-ic"]
+//   reg: mapped { addr = 0x3f00b200, size = 0x00000200 }
+//   interrupt-controller:
+//   #interrupt-cells: 0x000002
+//   interrupt-parent: 0x000018
+//   interrupts: 0x00000800000004
+//   phandle: <1>
+
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+use crate::context::Context;
 use crate::sync::Volatile;
 
 const ROUTING_CORE_MASK: u32 = 0b0111;
@@ -31,9 +44,64 @@ const REG_TIMER_RELOAD: usize = 0x38;
 const REG_TIMER_CORES: usize = 0x40;
 const REG_PENDING_BASE: usize = 0x60;
 
+const IRQ_COUNT: usize = 32;
+
+pub struct IsrTable([AtomicUsize; IRQ_COUNT]);
+
+impl IsrTable {
+    fn new(fallback: fn(&mut Context)) -> Self {
+        IsrTable(core::array::from_fn(|_| {
+            AtomicUsize::new(fallback as usize)
+        }))
+    }
+    pub fn get(&self, irq: usize) -> fn(&mut Context) {
+        let func = self.0[irq % IRQ_COUNT].load(Ordering::Relaxed);
+        unsafe { core::mem::transmute(func) }
+    }
+    pub fn set(&self, irq: usize, func: fn(&mut Context)) {
+        self.0[irq].store(func as usize, Ordering::SeqCst);
+    }
+}
+
 #[allow(nonstandard_style)]
 pub struct bcm2836_l1_intc_driver {
     base: *mut u32,
+    pub isr_table: IsrTable,
+}
+
+bitflags::bitflags! {
+    #[derive(Debug)]
+    pub struct IRQSource: u32 {
+        const LOCAL_TIMER = 1 << 11;
+        const AXI_OUTSTANDING = 1 << 10;
+        const PMU = 1 << 9;
+        const GPU = 1 << 8;
+        const MAILBOX_3 = 1 << 7;
+        const MAILBOX_2 = 1 << 6;
+        const MAILBOX_1 = 1 << 5;
+        const MAILBOX_0 = 1 << 4;
+        const CNTVIRQ = 1 << 3;
+        const CNTHPIRQ = 1 << 2;
+        const CNTPNSIRQ = 1 << 1;
+        const CNTPSIRQ = 1 << 0;
+    }
+}
+
+pub const IRQ_LOCAL_TIMER: usize = 11;
+pub const IRQ_AXI_OUTSTANDING: usize = 10;
+pub const IRQ_PMU: usize = 9;
+pub const IRQ_GPU: usize = 8;
+pub const IRQ_MAILBOX_3: usize = 7;
+pub const IRQ_MAILBOX_2: usize = 6;
+pub const IRQ_MAILBOX_1: usize = 5;
+pub const IRQ_MAILBOX_0: usize = 4;
+pub const IRQ_CNTVIRQ: usize = 3;
+pub const IRQ_CNTHPIRQ: usize = 2;
+pub const IRQ_CNTPNSIRQ: usize = 1;
+pub const IRQ_CNTPSIRQ: usize = 0;
+
+fn irq_not_handled(_ctx: &mut Context) {
+    panic!("IRQ not handled");
 }
 
 // TODO: reference https://s-matyukevich.github.io/raspberry-pi-os/docs/lesson03/linux/interrupt_controllers.html
@@ -48,43 +116,41 @@ impl bcm2836_l1_intc_driver {
     pub fn new(base_addr: *mut ()) -> Self {
         Self {
             base: base_addr.cast(),
+            isr_table: IsrTable::new(irq_not_handled),
         }
     }
 
-    pub fn timer_reload(&mut self) {
+    pub fn timer_reload(&self) {
         let local_timer_reload = Volatile(self.base.wrapping_byte_add(REG_TIMER_RELOAD));
         let clear_reload = CR_REG_CLEAR | CR_REG_RELOAD;
-        unsafe {
-            local_timer_reload.write(clear_reload);
-        }
+        unsafe { local_timer_reload.write(clear_reload) };
     }
 
-    pub fn timer_clear(&mut self) {
+    pub fn timer_clear(&self) {
         let local_timer_csr = Volatile(self.base.wrapping_byte_add(REG_TIMER_CSR));
         let new_csr = 0;
         unsafe { local_timer_csr.write(new_csr) };
 
         let local_timer_reload = Volatile(self.base.wrapping_byte_add(REG_TIMER_RELOAD));
         let clear_reload = CR_REG_CLEAR;
-        unsafe {
-            local_timer_reload.write(clear_reload);
-        }
+        unsafe { local_timer_reload.write(clear_reload) };
     }
 
     /// Reads the pending interrupt register for a core (0-3)
     ///
     /// Safety: ???
-    pub unsafe fn irq_source(&self, core: u32) -> u32 {
+    pub unsafe fn irq_source(&self, core: u32) -> IRQSource {
         assert!(core < 4);
         let pending_interrupt = Volatile(
             self.base
                 .wrapping_byte_add(REG_PENDING_BASE)
                 .wrapping_add(core as usize),
         );
-        unsafe { pending_interrupt.read() }
+        let source = unsafe { pending_interrupt.read() };
+        IRQSource::from_bits_retain(source)
     }
 
-    pub fn start_timer(&mut self, core: usize, ns: u64) {
+    pub fn start_timer(&self, core: usize, ns: u64) {
         let local_timer_routing = Volatile(self.base.wrapping_byte_add(REG_TIMER_ROUTING));
         let local_timer_csr = Volatile(self.base.wrapping_byte_add(REG_TIMER_CSR));
         let local_timer_reload = Volatile(self.base.wrapping_byte_add(REG_TIMER_RELOAD));
@@ -99,15 +165,54 @@ impl bcm2836_l1_intc_driver {
         unsafe { local_timer_csr.write(new_csr) };
 
         let core_mode = CNTPNS_IRQ;
-        unsafe {
-            local_timer_cores.add(core).write_volatile(core_mode);
-        }
+        unsafe { local_timer_cores.add(core).write_volatile(core_mode) };
 
         let clear_reload = CR_REG_CLEAR | CR_REG_RELOAD;
-        unsafe {
-            local_timer_reload.write(clear_reload);
-        }
+        unsafe { local_timer_reload.write(clear_reload) };
+    }
+
+    pub fn enable_irq_cntpnsirq(&self, core: usize) {
+        let local_timer_cores = self.base.wrapping_byte_add(REG_TIMER_CORES);
+        let core_mode = CNTPNS_IRQ;
+        unsafe { local_timer_cores.add(core).write_volatile(core_mode) };
     }
 }
 
+fn local_timer_handler(ctx: &mut Context) {
+    let irq = super::IRQ_CONTROLLER.get();
+    irq.timer_reload();
+    unsafe { crate::event::timer_handler(ctx) };
+}
+
+unsafe impl Sync for bcm2836_l1_intc_driver {}
 unsafe impl Send for bcm2836_l1_intc_driver {}
+
+#[no_mangle]
+pub unsafe extern "C" fn exception_handler_irq(
+    ctx: &mut Context,
+    _elr: u64,
+    _spsr: u64,
+    _esr: u64,
+    _arg: u64,
+) -> *mut Context {
+    let irq = super::IRQ_CONTROLLER.get();
+    let core = crate::arch::core_id() & 0b11;
+    let source = unsafe { irq.irq_source(core) };
+
+    // println!("irq {source:?} on core {core}");
+
+    let mut bits = source.bits();
+    let mut idx = 0;
+    while bits != 0 {
+        let shift = bits.trailing_zeros();
+
+        let irq_num = (idx + shift) as usize;
+        let handler = irq.isr_table.get(irq_num);
+        handler(ctx);
+
+        bits >>= shift + 1;
+        idx += shift + 1;
+    }
+
+    ctx
+}

--- a/crates/kernel/src/lib.rs
+++ b/crates/kernel/src/lib.rs
@@ -21,7 +21,6 @@ pub mod task;
 pub mod thread;
 pub mod util;
 
-use device::gic::gic_init_other_cores;
 use device::uart;
 use sync::SpinLock;
 
@@ -96,7 +95,7 @@ pub unsafe extern "C" fn kernel_entry_rust_alt(_x0: u32, _x1: u64, _x2: u64, _x3
     let sp = arch::debug_get_sp();
     println!("| starting core {id}, initial sp {:#x}", sp);
 
-    gic_init_other_cores();
+    device::gic::GIC.get().init_per_core();
 
     INIT_BARRIER.fetch_add(1, Ordering::SeqCst);
     START_BARRIER.fetch_add(1, Ordering::SeqCst);

--- a/crates/kernel/src/lib.rs
+++ b/crates/kernel/src/lib.rs
@@ -32,7 +32,6 @@ static START_WAIT: AtomicBool = AtomicBool::new(false);
 static INIT_WAIT: AtomicBool = AtomicBool::new(false);
 
 const FLAG_MULTICORE: bool = true;
-const FLAG_PREEMPTION: bool = true;
 
 extern "Rust" {
     fn kernel_main(device_tree: device_tree::DeviceTree);
@@ -66,14 +65,6 @@ pub unsafe extern "C" fn kernel_entry_rust(x0: u32, _x1: u64, _x2: u64, _x3: u64
     }
     INIT_WAIT.store(true, Ordering::SeqCst);
 
-    if FLAG_PREEMPTION && device::IRQ_CONTROLLER.is_initialized() {
-        println!("| enabling preemption on all cores");
-        let preemption_time_ns = 500_000;
-        let mut irq = device::IRQ_CONTROLLER.get().lock();
-        for core in 0..4 {
-            irq.start_timer(core, preemption_time_ns);
-        }
-    }
     device::init_devices_per_core();
 
     println!("| creating initial thread");

--- a/crates/kernel/src/sync/init.rs
+++ b/crates/kernel/src/sync/init.rs
@@ -24,7 +24,12 @@ impl<T> UnsafeInit<T> {
         }
         assert!(!self.initialized.swap(true, Ordering::SeqCst));
     }
+    #[track_caller]
     pub fn get(&self) -> &T {
+        debug_assert!(
+            self.initialized.load(Ordering::Relaxed),
+            "attempt to use an uninitialized UnsafeInit instance"
+        );
         unsafe { (*self.inner.get()).assume_init_ref() }
     }
     pub fn is_initialized(&self) -> bool {


### PR DESCRIPTION
Overall, this generalizes the handling of the interrupt controllers within the core of the kernel to allow it to support both the GIC (on rpi4b) and the bcm2836 interrupt controller (on rpi3b).

Changes:
- Move GIC globals and logic into a single struct with associated methods
- Runtime registration of per-core initialization logic for device drivers (a `Vec` of closures run on each core)
- Rename "timer" module to "bcm2836_intc"
- Improve interrupt handling in the rpi3 interrupt controller, to support the arm generic timer
- Use runtime code-patching to specify IRQ exception handler
- Enable preemption at a 1ms interval on both pi3 and pi4