### PR TITLE
Add gitattributes and editorconfig for line ending portability

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+
+[*.rs]
+indent_size = 4
+indent_style = space

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
This just adds `.gitattributes` and `.editorconfig` to hopefully ensure consistent line-endings.