### PR TITLE
Mapping a given physical page to a given virtual page in the kernel

### DIFF
--- a/crates/kernel/examples/vaToPaKernel.rs
+++ b/crates/kernel/examples/vaToPaKernel.rs
@@ -1,0 +1,72 @@
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+extern crate kernel;
+
+use alloc::alloc::{alloc, Layout};
+use alloc::boxed::Box;
+use core::ptr::addr_of;
+use kernel::*;
+
+const VIRTUAL_ADDR: usize = 0xFFFF_FFFF_FE00_0000 | 0x1E00000;
+
+const hello_chars: [u8; 5] = ['h' as u8, 'e' as u8, 'l' as u8, 'l' as u8, 'o' as u8];
+
+#[repr(C, align(4096))]
+struct SomePage([u8; 4096]);
+
+#[no_mangle]
+extern "Rust" fn kernel_main(_device_tree: device_tree::DeviceTree) {
+    println!("| starting kernel_main");
+    println!("Staring basic vmm test");
+
+    unsafe {
+        crate::arch::memory::init_physical_alloc();
+        crate::arch::memory::init();
+    }
+    println!("Init complete");
+
+    //hack: get a "page" from the heap and try to map it to some virtual address
+    let page_box = Box::<SomePage>::new(SomePage([0; 4096]));
+    let page_ptr: *mut SomePage = Box::into_raw(page_box);
+
+    let phys_addr: usize = crate::arch::memory::physical_addr((page_ptr).addr()).unwrap() as usize;
+
+    for i in 0..5 {
+        unsafe {
+            (*page_ptr).0[i] = hello_chars[i];
+        }
+    }
+
+    println!(
+        "Attempting to map pa {:x} to va: {:x}",
+        phys_addr, VIRTUAL_ADDR
+    );
+    unsafe {
+        let res: bool = crate::arch::memory::map_pa_to_va_kernel(phys_addr, VIRTUAL_ADDR);
+
+        if !res {
+            println!("Error case reached!");
+        }
+    }
+
+    println!("Done mapping");
+    let mut virt_ptr: *const u8 = VIRTUAL_ADDR as *const u8;
+    let mut all_good = true;
+
+    for i in 0..5 {
+        if unsafe { *(virt_ptr.wrapping_add(i)) != hello_chars[i] } {
+            all_good = false;
+            break;
+        }
+    }
+
+    if all_good {
+        println!("Physical to virtual mappping success");
+    } else {
+        println!("Physical to virtual mapping encountered an error!");
+    }
+
+    println!("End of basic vmm test");
+}

--- a/crates/kernel/examples/vaToPaKernel.rs
+++ b/crates/kernel/examples/vaToPaKernel.rs
@@ -32,9 +32,9 @@ extern "Rust" fn kernel_main(_device_tree: device_tree::DeviceTree) {
     let phys_addr: usize = crate::arch::memory::physical_addr((page_ptr).addr()).unwrap() as usize;
 
     unsafe {
-        core::ptr::copy(
-            &raw const HELLO_CHARS,
-            page_ptr as *mut [u8; 5],
+        core::ptr::copy_nonoverlapping(
+            &raw const HELLO_CHARS[0],
+            page_ptr as *mut u8,
             HELLO_CHARS.len(),
         );
     }

--- a/crates/kernel/src/arch/aarch64/memory/machine.rs
+++ b/crates/kernel/src/arch/aarch64/memory/machine.rs
@@ -323,15 +323,25 @@ impl TcrEl1 {
 }
 
 impl TableDescriptor {
-    const fn set_pa(self, pa: usize) -> Self {
+    pub const fn set_pa(self, pa: usize) -> Self {
         assert!(pa < (1 << 52), "field size mismatch");
         assert!(pa % (1 << 12) == 0, "alignment mismatch");
         self.difference(Self::NEXT_ADDR)
             .union(Self::from_bits_retain(pa as u64))
     }
 
+    //usize or u64
+    pub const fn get_pa(self) -> usize {
+        return ((self.bits() >> 12) & ((1 << 36) - 1)) as usize;
+    }
+
     pub const fn is_valid(self) -> bool {
         self.contains(Self::VALID)
+    }
+
+    //temporary, should be moved to more proper location
+    pub const fn is_table_descriptor(self) -> bool {
+        self.contains(Self::IS_TABLE_DESCRIPTOR)
     }
 
     pub const fn new(pa: usize) -> Self {

--- a/crates/kernel/src/arch/aarch64/memory/mod.rs
+++ b/crates/kernel/src/arch/aarch64/memory/mod.rs
@@ -7,7 +7,7 @@ use machine::{at_s1e1r, LeafDescriptor};
 pub use vmm::{map_device, map_device_block, map_physical, map_physical_noncacheable};
 
 pub use machine::at_s1e0r;
-pub use vmm::{create_user_region, init_physical_alloc};
+pub use vmm::{create_user_region, init_physical_alloc, map_pa_to_va_kernel};
 
 pub const INIT_TCR_EL1: u64 = machine::TcrEl1::default().bits();
 pub const INIT_TRANSLATION: u64 = LeafDescriptor::new(0)

--- a/crates/kernel/src/arch/aarch64/memory/vmm.rs
+++ b/crates/kernel/src/arch/aarch64/memory/vmm.rs
@@ -5,8 +5,6 @@ use core::{
     ptr::{self, addr_of, NonNull},
 };
 
-//Create error enum and return a result - look in lz4/src/frame.rs has error enum and func on line 174 has example usage
-
 use super::{
     machine::{LeafDescriptor, TableDescriptor, TranslationDescriptor},
     physical_addr,
@@ -146,9 +144,7 @@ impl Display for MappingError {
     }
 }
 
-//This should ideally be made more generalizable in the future
 //TODO: give option of setting bits for the mapping
-//TODO: change return type to something more appropriate
 //Maybe add option to map huge pages here
 pub unsafe fn map_pa_to_va_kernel(pa: usize, va: usize) -> Result<(), MappingError> {
     //TODO: stop using these constants
@@ -161,7 +157,6 @@ pub unsafe fn map_pa_to_va_kernel(pa: usize, va: usize) -> Result<(), MappingErr
         unsafe { KERNEL_TRANSLATION_TABLE.0[table_index].table };
 
     if !table_descriptor.is_table_descriptor() {
-        //huge page here instead of table descriptor
         //Error: Huge page instead of table descriptor
         return Err(MappingError::HugePagePresent);
     }
@@ -317,9 +312,9 @@ pub unsafe fn map_physical_noncacheable(pa_start: usize, size: usize) -> NonNull
     }
 }
 
+//This is two adjacent pages all filled with leaf descriptors
 #[no_mangle]
 static mut KERNEL_LEAF_TABLE: KernelLeafTable =
-    //This is two adjacent pages all filled with leaf descriptors
     KernelLeafTable([LeafDescriptor::empty(); PG_SZ / 8 * 2]);
 
 #[no_mangle]


### PR DESCRIPTION
This is the base functionality to map a given physical page to a given virtual page. To test, please build and run the vaToPaKernel.rs example. The way that errors are handled in the `map_pa_to_va_kernel` function is by returning a boolean on if the mapping procedure succeeded or not, so I would be grateful for suggestions on ways to improve this.