### PR TITLE
Document and generalize async syscall handler logic

### DIFF
--- a/crates/init/src/main.rs
+++ b/crates/init/src/main.rs
@@ -41,7 +41,7 @@ fn spawn_elf(elf: elf::Elf<'_>) -> sys::ChannelDesc {
 pub extern "C" fn main() {
     let archive = initfs::Archive::load(ARCHIVE).unwrap();
 
-    let mut buf = [0; 0x10000];
+    let mut buf = [0; 0x18000];
     let (_, file) = archive.find_file(b"example.elf").unwrap();
     let file = archive.read_file(file, &mut buf).unwrap();
 

--- a/crates/kernel/src/event/async_handler.rs
+++ b/crates/kernel/src/event/async_handler.rs
@@ -1,0 +1,269 @@
+use core::arch::asm;
+use core::future::Future;
+use core::pin::Pin;
+use core::task::Poll;
+
+use alloc::boxed::Box;
+
+use super::context::{enter_event_loop, Context, CORES};
+use super::{task, thread};
+use crate::event;
+
+pub trait AsyncFnCustomSend<Args> {
+    type Output;
+    type CallOnceFuture: Future<Output = Self::Output> + Send;
+    fn call(self, args: Args) -> Self::CallOnceFuture;
+}
+
+impl<A, F, Fu> AsyncFnCustomSend<A> for F
+where
+    F: FnOnce(A) -> Fu,
+    Fu: Future + Send,
+{
+    type Output = Fu::Output;
+    type CallOnceFuture = Fu;
+    fn call(self, args: A) -> Self::CallOnceFuture {
+        self(args)
+    }
+}
+
+/// Run an asynchronous exception handler for a thread, such as a syscall
+/// or page fault handler.
+///
+/// This should be called directly from a handler function, and its
+/// return value should be returned from the handler.  The async closure
+/// will be polled once; if it finished immediately (does not yield), it
+/// will directly return back to the user thread without a full context
+/// switch.  If the async closure yields, it will suspend and save the
+/// state of the user thread.
+///
+/// The closure may at any point resume the execution of the user thread
+/// with [`HandlerContext::resume`] or [`HandlerContext::resume_final`];
+/// `resume` will schedule the thread to be run (or run it immediately,
+/// if the closure hasn't yet yielded) while leaving the rest of the
+/// closure to run concurrently; `resume_final` will schedule the thread
+/// to run after the closure completes.
+///
+/// The closure may access and modify the registers and memory of the
+/// associated thread, through [`HandlerContext::regs`] and
+/// [`HandlerContext::with_user_vmem`].  `regs` returns a reference to
+/// the register context, though it cannot be stored across `await`
+/// points (since the context is moved at the first yield-point).
+///
+/// [`HandlerContext::with_user_vmem`] runs a callback with access to
+/// the virtual address space of the user.  It is not sound to access
+/// user pointers from outside of these callbacks, as the user address
+/// space may not have been restored during task context switches within
+/// the kernel.
+///
+/// The handler must return the [`ResumedContext`] struct returned by
+/// either [`HandlerContext::resume`] or [`HandlerContext::resume_final`].
+///
+/// TODO: expose a mechanism to take manual control over the thread --
+/// adding it to wait queues, freeing it, etc.
+#[must_use]
+pub fn run_async_handler<Fn>(ctx: &mut Context, handler: Fn) -> *mut Context
+where
+    Fn: for<'a> AsyncFnCustomSend<HandlerContext<'a>, Output = ResumedContext> + 'static,
+{
+    // TODO: ensure preemption/interrupts disabled before this point
+    let thread = CORES.with_current(|core| core.thread.take());
+    let mut thread = thread.expect("usermode syscall without active thread");
+    thread.last_context = ctx.into();
+
+    // TODO: avoid allocating in the syscall handler?
+    let mut future = new_handler_future(thread, handler);
+
+    let task_id = task::TASKS.alloc_task_slot();
+    let waker = task::create_waker(task_id);
+    let mut context = core::task::Context::from_waker(&waker);
+
+    // Run the handler future until it suspends once
+    match Future::poll(future.as_mut(), &mut context) {
+        Poll::Ready(()) => {
+            // If the handler finished immediately, remove the task
+            // and return back to the user directly.
+            task::TASKS.remove_task(task_id);
+
+            let thread = unsafe { &mut *future.data.thread.get() }.take().unwrap();
+            CORES.with_current(|core| core.thread.set(Some(thread)));
+            ctx
+        }
+        Poll::Pending => {
+            future.data.in_handler.set(false);
+
+            if !future.data.suspend_thread.get() {
+                let thread = unsafe { &mut *future.data.thread.get() }.take().unwrap();
+                CORES.with_current(|core| core.thread.set(Some(thread)));
+
+                // Return back to the user context
+                ctx
+            } else {
+                // The handler yielded; suspend the current thread, and set
+                // up the future to reschedule the thread when it finishes.
+                let thread = unsafe { &mut *future.data.thread.get() }.as_mut().unwrap();
+                unsafe { thread.save_context(ctx.into()) };
+
+                let woken = task::TASKS.return_task(task_id, task::Task::new(future));
+                if woken {
+                    event::SCHEDULER.add_task(event::Event::AsyncTask(task_id));
+                }
+
+                // Switch back to the event loop.
+                unsafe { enter_event_loop() };
+            }
+        }
+    }
+}
+
+struct OuterData {
+    in_handler: core::cell::Cell<bool>,
+    suspend_thread: core::cell::Cell<bool>,
+    thread: core::cell::UnsafeCell<Option<Box<thread::Thread>>>,
+}
+
+pub struct HandlerContext<'a> {
+    outer_data: &'a OuterData,
+}
+
+impl HandlerContext<'_> {
+    fn cur_thread_mut(&mut self) -> &mut Option<Box<thread::Thread>> {
+        unsafe { &mut *self.outer_data.thread.get() }
+    }
+    fn cur_thread(&self) -> &thread::Thread {
+        unsafe { &*self.outer_data.thread.get() }
+            .as_deref()
+            .unwrap()
+    }
+
+    pub async fn resume(mut self) -> ResumedContext {
+        if self.outer_data.in_handler.get() {
+            // Haven't yielded yet; yield to the handler and tell
+            // it to resume running the user thread.
+            // TODO: priority of user thread vs kernel task?
+            self.outer_data.suspend_thread.set(false);
+            task::yield_future().await;
+        } else {
+            let thread = self.cur_thread_mut().take().unwrap();
+            event::SCHEDULER.add_task(event::Event::ScheduleThread(thread));
+        }
+        ResumedContext(())
+    }
+
+    pub fn resume_final(self) -> ResumedContext {
+        ResumedContext(())
+    }
+
+    pub fn regs(&mut self) -> ContextRef<'_> {
+        let thread = self.cur_thread_mut().as_mut().unwrap();
+        ContextRef {
+            inner: unsafe { thread.last_context.as_mut() },
+            marker: core::marker::PhantomData,
+        }
+    }
+
+    pub fn with_user_vmem<F, O>(&self, callback: F) -> O
+    where
+        F: FnOnce() -> O,
+    {
+        if self.outer_data.in_handler.get() {
+            // User virtual memory is still enabled, haven't yielded yet
+            callback()
+        } else {
+            // This handler has already yielded; user virtual memory likely
+            // hasn't been switched back to the correct address space.
+            let thread = self.cur_thread();
+            let user_ttbr0 = thread.user_regs.as_ref().unwrap().ttbr0_el1;
+
+            let cur_ttbr0: usize;
+            unsafe { asm!("mrs {0}, TTBR0_EL1", out(reg) cur_ttbr0) };
+
+            // If the page table has changed, switch back to this thread's
+            // address space.
+            if cur_ttbr0 != user_ttbr0 {
+                unsafe {
+                    asm!("msr TTBR0_EL1, {0}", "isb", "dsb sy", "tlbi vmalle1is", "dsb sy", in(reg) user_ttbr0)
+                };
+            }
+
+            callback()
+        }
+    }
+}
+
+unsafe impl Send for HandlerContext<'_> {}
+
+pub struct ContextRef<'a> {
+    inner: &'a mut Context,
+    // To ensure ContextRef: !Send, and can't be kept across await points.
+    marker: core::marker::PhantomData<*mut ()>,
+}
+
+impl core::ops::Deref for ContextRef<'_> {
+    type Target = Context;
+    fn deref(&self) -> &Self::Target {
+        &*self.inner
+    }
+}
+impl core::ops::DerefMut for ContextRef<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut *self.inner
+    }
+}
+
+pub struct ResumedContext(());
+
+struct HandlerFuture<F> {
+    inner: core::mem::MaybeUninit<F>,
+    data: OuterData,
+}
+
+fn new_handler_future<F>(
+    thread: Box<thread::Thread>,
+    f: F,
+) -> Pin<Box<HandlerFuture<<F as AsyncFnCustomSend<HandlerContext<'static>>>::CallOnceFuture>>>
+where
+    F: for<'a> AsyncFnCustomSend<HandlerContext<'a>, Output = ResumedContext>,
+{
+    let mut this = Box::pin(HandlerFuture {
+        inner: core::mem::MaybeUninit::uninit(),
+        data: OuterData {
+            thread: core::cell::UnsafeCell::new(Some(thread)),
+            in_handler: core::cell::Cell::new(true),
+            suspend_thread: core::cell::Cell::new(true),
+        },
+    });
+
+    let this_ref = unsafe { this.as_mut().get_unchecked_mut() };
+    let context = HandlerContext {
+        outer_data: &this_ref.data,
+    };
+    // Convert the self-referential context to a 'static context
+    // Since the function F accepts SyscallContext values of any lifetime,
+    // its use of the lifetime will be limited to the bounds of the function,
+    // making this sound.  (The lifetime 'a in the function is technically
+    // 'static, but it is impossible to observe that from within the function.)
+    let fake_context = unsafe { core::mem::transmute::<HandlerContext, HandlerContext>(context) };
+    this_ref.inner.write(f.call(fake_context));
+    this
+}
+
+unsafe impl<F: Send> Send for HandlerFuture<F> {}
+
+impl<F> Future for HandlerFuture<F>
+where
+    F: Future<Output = ResumedContext>,
+{
+    type Output = ();
+    fn poll(self: Pin<&mut Self>, ctx: &mut core::task::Context<'_>) -> Poll<Self::Output> {
+        let this = unsafe { Pin::into_inner_unchecked(self) };
+        let inner = unsafe { Pin::new_unchecked(this.inner.assume_init_mut()) };
+
+        let _context = core::task::ready!(inner.poll(ctx));
+        if !this.data.in_handler.get() {
+            let thread = unsafe { &mut *this.data.thread.get() }.take().unwrap();
+            event::SCHEDULER.add_task(event::Event::ScheduleThread(thread));
+        }
+        ().into()
+    }
+}

--- a/crates/kernel/src/event/task.rs
+++ b/crates/kernel/src/event/task.rs
@@ -8,7 +8,7 @@ use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 use super::SCHEDULER;
 use crate::sync::SpinLock;
 
-pub fn spawn_async(future: impl Future<Output = ()> + Send + Sync + 'static) {
+pub fn spawn_async(future: impl Future<Output = ()> + Send + 'static) {
     let task = TASKS.add_task(Task {
         future: Box::pin(future),
     });
@@ -18,11 +18,11 @@ pub fn spawn_async(future: impl Future<Output = ()> + Send + Sync + 'static) {
 pub static TASKS: TaskList = TaskList::new();
 
 pub struct Task {
-    future: Pin<Box<dyn Future<Output = ()> + Send + Sync>>,
+    future: Pin<Box<dyn Future<Output = ()> + Send>>,
 }
 
 impl Task {
-    pub fn new(future: Pin<Box<dyn Future<Output = ()> + Send + Sync>>) -> Self {
+    pub fn new(future: Pin<Box<dyn Future<Output = ()> + Send>>) -> Self {
         Task { future }
     }
     pub fn poll(&mut self, context: &mut Context) -> Poll<()> {

--- a/crates/kernel/src/event/thread.rs
+++ b/crates/kernel/src/event/thread.rs
@@ -4,6 +4,9 @@ use core::ptr::NonNull;
 use super::context::{context_switch, Context, SwitchAction, CORES};
 use super::{Event, SCHEDULER};
 
+/// A handle for a kernel or user thread, which owns its stack, and
+/// while the thread isn't running, stores the saved register state of
+/// the thread.
 pub struct Thread {
     pub last_context: NonNull<Context>,
     pub stack: NonNull<[u128]>,
@@ -24,6 +27,7 @@ unsafe impl Send for Thread {}
 unsafe impl Sync for Thread {}
 
 impl Thread {
+    /// Create a kernel thread from the given stack and closure
     unsafe fn from_fn<F>(stack: NonNull<[u128]>, func: F) -> Box<Self>
     where
         F: FnOnce() + Send + 'static,
@@ -48,6 +52,8 @@ impl Thread {
         unsafe { Self::new(stack, stack_offset, Some(fn_ptr)) }
     }
 
+    /// Create a new user thread with the given stack pointer, initial
+    /// program counter, and initial page table (`ttbr0`).
     pub unsafe fn new_user(sp: usize, entry: usize, ttbr0: usize) -> Box<Self> {
         let data = Context {
             regs: [0; 31],
@@ -71,6 +77,10 @@ impl Thread {
         thread
     }
 
+    /// Create a new kernel thread with the given stack and a function
+    /// to run when starting the thread.
+    ///
+    /// Stack must have been created with [`Box::into_raw`]
     unsafe fn new(
         stack: NonNull<[u128]>,
         stack_offset: usize,
@@ -90,9 +100,7 @@ impl Thread {
             link_reg: init_thread as usize,
             spsr: 0b0101, // Stay in EL1, using the EL1 sp
         };
-        unsafe {
-            core::ptr::write(context.as_ptr(), data);
-        }
+        unsafe { core::ptr::write(context.as_ptr(), data) };
 
         Box::new(Thread {
             stack,
@@ -103,6 +111,15 @@ impl Thread {
         })
     }
 
+    /// Save the given register context into the thread's state;
+    /// if the thread is a user thread, it copies the register context
+    /// into a space in the [`Thread`] struct (as the context is stored
+    /// on the temporary kernel stack).  If the thread is a kernel thread,
+    /// the context is stored on the kernel stack, so this can leave the
+    /// context in-place on the thread's stack.
+    ///
+    /// If this is a user thread, it saves the *current* values of
+    /// `TTBR0_EL1` and `SP_EL0` into the user's stack.
     pub unsafe fn save_context(&mut self, context: NonNull<Context>) {
         if let Some(user) = &mut self.user_regs {
             unsafe { core::arch::asm!("mrs {}, TTBR0_EL1", out(reg) user.ttbr0_el1) };
@@ -119,6 +136,7 @@ impl Thread {
         }
     }
 
+    /// Switch into the thread, restoring its context
     pub unsafe fn enter_thread(self: Box<Self>) -> ! {
         let next_ctx = self.last_context.as_ptr();
 
@@ -181,6 +199,7 @@ impl<F: FnOnce()> Callback for F {
 
 const STACK_SIZE: usize = 16384;
 
+/// Spawn a kernel thread that runs the given closure.
 pub fn thread<F>(f: F)
 where
     F: FnOnce() + Send + 'static,
@@ -206,10 +225,12 @@ extern "C" fn init_thread() {
     stop();
 }
 
+/// Yield control of the current thread, running it again in the future.
 pub fn yield_() {
     context_switch(SwitchAction::Yield);
 }
 
+/// Exit the current thread
 pub fn stop() -> ! {
     context_switch(SwitchAction::FreeThread);
     unreachable!()

--- a/crates/kernel/src/syscall.rs
+++ b/crates/kernel/src/syscall.rs
@@ -1,12 +1,4 @@
-use core::future::Future;
-use core::pin::Pin;
-use core::task::Poll;
-
-use alloc::boxed::Box;
-
-use crate::event::context::{enter_event_loop, Context, CORES};
 use crate::event::exceptions::register_syscall_handler;
-use crate::event::{self, task, thread};
 
 pub mod channel;
 pub mod proc;
@@ -23,93 +15,5 @@ pub unsafe fn register_syscalls() {
         register_syscall_handler(7, channel::sys_channel);
         register_syscall_handler(8, channel::sys_send);
         register_syscall_handler(9, channel::sys_recv);
-    }
-}
-
-pub fn run_async_syscall<const N: usize, F>(ctx: &mut Context, future: F) -> *mut Context
-where
-    F: Future<Output = [usize; N]> + Send + Sync + 'static,
-{
-    // TODO: avoid allocating in the syscall handler?
-    let mut future = Box::pin(HandlerWrapper {
-        inner: future,
-        data: HandlerData {
-            returns: None,
-            should_schedule: None,
-        },
-    });
-
-    let task_id = task::TASKS.alloc_task_slot();
-    let waker = task::create_waker(task_id);
-    let mut context = core::task::Context::from_waker(&waker);
-
-    // Run the handler future until it suspends once
-    match Future::poll(future.as_mut(), &mut context) {
-        Poll::Ready(()) => {
-            // If the handler finished immediately, remove the task
-            // and return back to the user directly.
-            task::TASKS.remove_task(task_id);
-            let data = future.as_mut().get_data();
-            let return_arr = data.returns.take().unwrap();
-
-            ctx.regs[..N].copy_from_slice(&return_arr);
-            ctx
-        }
-        Poll::Pending => {
-            // The handler yielded; suspend the current thread, and set
-            // up the future to reschedule the thread when it finishes.
-
-            let thread = CORES.with_current(|core| core.thread.take());
-            let mut thread = thread.expect("usermode syscall without active thread");
-            unsafe { thread.save_context(ctx.into()) };
-
-            let data = future.as_mut().get_data();
-            data.should_schedule = Some(thread);
-
-            let woken = task::TASKS.return_task(task_id, task::Task::new(future));
-            if woken {
-                event::SCHEDULER.add_task(event::Event::AsyncTask(task_id));
-            }
-
-            // Switch back to the event loop.
-            unsafe { enter_event_loop() };
-        }
-    }
-}
-
-struct HandlerData<const N: usize> {
-    returns: Option<[usize; N]>,
-    should_schedule: Option<Box<thread::Thread>>,
-}
-
-struct HandlerWrapper<const N: usize, F> {
-    inner: F,
-    data: HandlerData<N>,
-}
-
-impl<const N: usize, F> HandlerWrapper<N, F> {
-    fn get_data(self: Pin<&mut Self>) -> &mut HandlerData<N> {
-        unsafe { &mut self.get_unchecked_mut().data }
-    }
-}
-
-impl<const N: usize, F> Future for HandlerWrapper<N, F>
-where
-    F: Future<Output = [usize; N]>,
-{
-    type Output = ();
-    fn poll(self: Pin<&mut Self>, ctx: &mut core::task::Context<'_>) -> Poll<Self::Output> {
-        let this = unsafe { Pin::into_inner_unchecked(self) };
-        let inner = unsafe { Pin::new_unchecked(&mut this.inner) };
-
-        let arr = core::task::ready!(inner.poll(ctx));
-        if let Some(mut thread) = this.data.should_schedule.take() {
-            let ctx = thread.context.as_mut().unwrap();
-            ctx.regs[..N].copy_from_slice(&arr);
-            event::SCHEDULER.add_task(event::Event::ScheduleThread(thread));
-        } else {
-            this.data.returns = Some(arr);
-        }
-        ().into()
     }
 }

--- a/crates/kernel/src/syscall.rs
+++ b/crates/kernel/src/syscall.rs
@@ -4,7 +4,7 @@ use core::task::Poll;
 
 use alloc::boxed::Box;
 
-use crate::event::context::{deschedule_thread, Context, DescheduleAction, CORES};
+use crate::event::context::{enter_event_loop, Context, CORES};
 use crate::event::exceptions::register_syscall_handler;
 use crate::event::{self, task, thread};
 
@@ -72,7 +72,7 @@ where
             }
 
             // Switch back to the event loop.
-            unsafe { deschedule_thread(DescheduleAction::FreeThread, None) }
+            unsafe { enter_event_loop() };
         }
     }
 }

--- a/crates/kernel/src/syscall/channel.rs
+++ b/crates/kernel/src/syscall/channel.rs
@@ -1,14 +1,12 @@
-use core::arch::asm;
 use core::num::NonZeroU32;
 
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 
+use crate::event::async_handler::{run_async_handler, HandlerContext};
 use crate::event::context::Context;
 use crate::ringbuffer;
 use crate::sync::SpinLock;
-
-use super::run_async_syscall;
 
 // TODO: tracking ownership of objects
 pub struct ObjectDescriptor(core::num::NonZeroU32);
@@ -73,9 +71,10 @@ pub unsafe fn sys_send(ctx: &mut Context) -> *mut Context {
     let buf_len = ctx.regs[3];
     let flags = SendRecvFlags::from_bits_truncate(ctx.regs[4] as u32);
 
-    run_async_syscall(ctx, async move {
+    run_async_handler(ctx, async move |mut context: HandlerContext<'_>| {
         let Some(desc) = NonZeroU32::new(desc as u32) else {
-            return [(-1isize) as usize];
+            context.regs().regs[0] = -1isize as usize;
+            return context.resume_final();
         };
         let sender = OBJECTS
             .lock()
@@ -90,14 +89,15 @@ pub unsafe fn sys_send(ctx: &mut Context) -> *mut Context {
         let Some((mut send, recv)) = sender else {
             // TODO: proper approach to mpsc channels?
             println!("Skipping message, channel in-use or non-existant!");
-            return [(-1isize) as usize];
+            context.regs().regs[0] = -1isize as usize;
+            return context.resume_final();
         };
 
-        // user virtual memory is still enabled, haven't yielded yet
-
-        let msg_ptr = msg_ptr as *const UserMessage;
-        assert!(msg_ptr.is_aligned()); // TODO: check user access validity
-        let user_message = unsafe { core::ptr::read(msg_ptr) };
+        let user_message = context.with_user_vmem(|| {
+            let msg_ptr = msg_ptr as *const UserMessage;
+            assert!(msg_ptr.is_aligned()); // TODO: check user access validity
+            unsafe { core::ptr::read(msg_ptr) }
+        });
 
         // TODO: validate ownership of objects
         let objects = user_message
@@ -127,9 +127,9 @@ pub unsafe fn sys_send(ctx: &mut Context) -> *mut Context {
                 data,
             });
             if r.is_err() {
-                res = [-2isize as usize];
+                res = -2isize as usize;
             } else {
-                res = [0];
+                res = 0;
             }
         } else {
             send.send(Message {
@@ -138,12 +138,13 @@ pub unsafe fn sys_send(ctx: &mut Context) -> *mut Context {
                 data,
             })
             .await;
-            res = [0];
+            res = 0;
         }
 
         OBJECTS.lock()[desc.get() as usize] = Some(Object::Channel { send, recv });
 
-        res
+        context.regs().regs[0] = res;
+        context.resume_final()
     })
 }
 
@@ -154,12 +155,10 @@ pub unsafe fn sys_recv(ctx: &mut Context) -> *mut Context {
     let buf_cap = ctx.regs[3];
     let flags = SendRecvFlags::from_bits_truncate(ctx.regs[4] as u32);
 
-    let user_ttbr0: usize;
-    unsafe { asm!("mrs {0}, TTBR0_EL1", out(reg) user_ttbr0) };
-
-    run_async_syscall(ctx, async move {
+    run_async_handler(ctx, async move |mut context: HandlerContext<'_>| {
         let Some(desc) = NonZeroU32::new(desc as u32) else {
-            return [(-1isize) as usize];
+            context.regs().regs[0] = -1isize as usize;
+            return context.resume_final();
         };
         let receiver = OBJECTS
             .lock()
@@ -175,7 +174,8 @@ pub unsafe fn sys_recv(ctx: &mut Context) -> *mut Context {
         let Some((send, mut recv)) = receiver else {
             // TODO: proper approach to mpsc channels?
             println!("Skipping message, channel in-use or non-existant!");
-            return [(-1isize) as usize];
+            context.regs().regs[0] = -1isize as usize;
+            return context.resume_final();
         };
 
         let message;
@@ -188,44 +188,36 @@ pub unsafe fn sys_recv(ctx: &mut Context) -> *mut Context {
         OBJECTS.lock()[desc.get() as usize] = Some(Object::Channel { send, recv });
 
         let Some(message) = message else {
-            return [-2isize as usize];
+            context.regs().regs[0] = -2isize as usize;
+            return context.resume_final();
         };
 
         let user_message = UserMessage {
             tag: message.tag,
             objects: message.objects.map(|s| s.map(|o| o.0.get()).unwrap_or(0)),
         };
-
         // TODO: track ownership of objects
 
-        // Re-enable user virtual memory; it could have been
-        // disabled / switched, if recv yielded and ran a different
-        // user thread.
-        let cur_ttbr0: usize;
-        unsafe { asm!("mrs {0}, TTBR0_EL1", out(reg) cur_ttbr0) };
-        if cur_ttbr0 != user_ttbr0 {
-            // Enable the user-mode address space in this thread
-            unsafe {
-                asm!("msr TTBR0_EL1, {0}", "isb", "dsb sy", "tlbi vmalle1is", "dsb sy", in(reg) user_ttbr0)
-            };
-        }
-
         let mut data_len = 0;
-        if let Some(data) = message.data {
-            // TODO: validate memory region
-            let buf_ptr = buf_ptr as *mut u8;
-            let kbuf_ptr = data.as_ptr();
-            let actual_len = data.len().min(buf_cap); // TODO: ??? truncate ???
-            unsafe {
-                core::ptr::copy_nonoverlapping(kbuf_ptr, buf_ptr, actual_len);
+
+        context.with_user_vmem(|| {
+            if let Some(data) = message.data {
+                // TODO: validate memory region
+                let buf_ptr = buf_ptr as *mut u8;
+                let kbuf_ptr = data.as_ptr();
+                let actual_len = data.len().min(buf_cap); // TODO: ??? truncate ???
+                unsafe {
+                    core::ptr::copy_nonoverlapping(kbuf_ptr, buf_ptr, actual_len);
+                }
+                data_len = data.len();
             }
-            data_len = data.len();
-        }
 
-        let msg_ptr = msg_ptr as *mut UserMessage;
-        assert!(msg_ptr.is_aligned()); // TODO: check user access validity
-        unsafe { core::ptr::write(msg_ptr, user_message) };
+            let msg_ptr = msg_ptr as *mut UserMessage;
+            assert!(msg_ptr.is_aligned()); // TODO: check user access validity
+            unsafe { core::ptr::write(msg_ptr, user_message) };
+        });
 
-        [data_len]
+        context.regs().regs[0] = data_len;
+        context.resume_final()
     })
 }


### PR DESCRIPTION
The main interface for this is `kernel::event::async_handler::run_async_handler`; for example uses, see the syscall implementations in `kernel::syscall::channel`.