### PR TITLE
Remove dependency on objcopy by using our elf crate

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,8 +1,5 @@
-
 [build]
 # target = "aarch64-unknown-none-softfloat"
 
-# [unstable]
-# unstable-options = true
-# build-std = ["std", "panic_abort"]
-# build-std-features = ["panic_immediate_abort"]
+[alias]
+dump-img = ["run", "-p", "elf", "--bin", "dump_img", "--"]

--- a/crates/elf/src/bin/dump_img.rs
+++ b/crates/elf/src/bin/dump_img.rs
@@ -1,0 +1,86 @@
+use std::fs;
+use std::io::{Seek, SeekFrom, Write};
+use std::path::Path;
+
+// Equivalent to 'objcopy -O binary [input] [output]`:
+// > objcopy can be used to generate a raw binary file by using an
+// > output target of binary (e.g., use -O binary).  When objcopy
+// > generates a raw binary file, it will essentially produce a memory
+// > dump of the contents of the input object file.  All symbols and
+// > relocation information will be discarded.  The memory dump will
+// > start at the load address of the lowest section copied into the
+// > output file.
+
+fn main() {
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    if args.len() != 2 {
+        println!("Usage: dump_img [input.elf] [output.bin]");
+        std::process::exit(1);
+    }
+
+    let input = &args[0];
+    let output = &args[1];
+
+    if let Err(e) = dump_file(input.as_ref(), output.as_ref()) {
+        eprintln!("Error: {}", e);
+        std::process::exit(1);
+    }
+}
+
+#[derive(Debug)]
+enum DumpError {
+    NoProgramHeaders,
+    NoLoadableSegments,
+    MissingSegmentData,
+}
+
+impl core::fmt::Display for DumpError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            DumpError::NoProgramHeaders => write!(f, "input elf has no segments"),
+            DumpError::NoLoadableSegments => write!(f, "input elf has no loadable segments"),
+            DumpError::MissingSegmentData => write!(f, "missing data for a segment"),
+        }
+    }
+}
+
+impl core::error::Error for DumpError {}
+
+fn dump_file(input: &Path, output: &Path) -> Result<(), Box<dyn core::error::Error>> {
+    let data: Vec<u8> = fs::read(input)?;
+    let elf = elf::Elf::new(&data)?;
+
+    let phdrs = elf
+        .program_headers()
+        .ok_or(DumpError::NoProgramHeaders)?
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let min_segment_base = phdrs
+        .iter()
+        .filter(|phdr| matches!(phdr.p_type, elf::program_header::Type::Load))
+        .map(|phdr| phdr.p_vaddr)
+        .min()
+        .ok_or(DumpError::NoLoadableSegments)?;
+
+    let mut output_file = std::fs::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .create(true)
+        .open(output)?;
+
+    for phdr in phdrs {
+        if matches!(phdr.p_type, elf::program_header::Type::Load) {
+            let data = elf
+                .segment_data(&phdr)
+                .ok_or(DumpError::MissingSegmentData)?;
+
+            output_file.seek(SeekFrom::Start(phdr.p_vaddr - min_segment_base))?;
+            output_file.write_all(data)?;
+            // Skip writing (memsize - filesize) zeroes; instead rely
+            // on OOB seeks to zero intermediate regions and truncate
+            // the final trailing zeroes.
+        }
+    }
+
+    Ok(())
+}

--- a/crates/init/build.sh
+++ b/crates/init/build.sh
@@ -26,4 +26,6 @@ else
 fi
 
 cp "${BINARY}" init.elf
-objcopy -I elf32-little -O binary "${BINARY}" init.bin
+
+# equivalent to 'objcopy -I elf64-little -O binary "${BINARY}" init.bin'
+cargo run -p elf --bin dump_img -- "${BINARY}" init.bin

--- a/crates/kernel/.cargo/config.toml
+++ b/crates/kernel/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-target = "aarch64-unknown-none-softfloat"

--- a/crates/kernel/justfile
+++ b/crates/kernel/justfile
@@ -171,7 +171,7 @@ build example=example profile=profile target=target: _check-rust-version _check-
 
     # Create kernel files
     cp "${BINARY}" kernel.elf
-    objcopy -I elf64-little -O binary "${BINARY}" kernel.bin
+    cargo dump-img "${BINARY}" kernel.bin
 
     set +x
     echo -e "{{green}}{{bold}}Build successful!{{reset}}"

--- a/crates/kernel/scripts/build.sh
+++ b/crates/kernel/scripts/build.sh
@@ -8,14 +8,16 @@ PROFILE=${PROFILE-"release"}
 
 # cargo clean
 cargo rustc --profile="${PROFILE}" --example="${EXAMPLE}" \
-    --target=${TARGET} -- \
+    --target="${TARGET}" -- \
     -C relocation-model=static
 
 if test "$PROFILE" = "dev" ; then
-    BINARY=../../target/${TARGET}/debug/examples/${EXAMPLE}
+    BINARY="../../target/${TARGET}/debug/examples/${EXAMPLE}"
 else
-    BINARY=../../target/${TARGET}/${PROFILE}/examples/${EXAMPLE}
+    BINARY="../../target/${TARGET}/${PROFILE}/examples/${EXAMPLE}"
 fi
 
 cp "${BINARY}" kernel.elf
-llvm-objcopy -O binary "${BINARY}" kernel.bin
+
+# equivalent to 'objcopy -I elf64-little -O binary "${BINARY}" init.bin'
+cargo dump-img "${BINARY}" kernel.bin


### PR DESCRIPTION
With this, we now only depend on the rust toolchain, with no direct dependencies on other C build tools.

Our current external dependencies are `cargo`, `bash`, `python3`, and some shell utils (`realpath`, `dirname`, `mktemp`, and `find`).