### PR TITLE
Basic kernel testing harness

### DIFF
--- a/crates/kernel/examples/tests.rs
+++ b/crates/kernel/examples/tests.rs
@@ -1,0 +1,88 @@
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+#[macro_use]
+extern crate kernel;
+
+use event::task::spawn_async;
+use kernel::*;
+
+#[macro_use]
+#[path = "tests/test_impl.rs"]
+mod test_impl;
+use test_impl::*;
+
+#[path = "tests/mod.rs"]
+mod tests;
+
+#[no_mangle]
+extern "Rust" fn kernel_main(device_tree: device_tree::DeviceTree<'static>) {
+    spawn_async(async move {
+        main(device_tree).await;
+        shutdown();
+    });
+    event::thread::stop();
+}
+
+pub const BOLD: &str = "\x1b[1m";
+pub const GREEN: &str = "\x1b[32;1m";
+pub const RED: &str = "\x1b[31;1m";
+pub const YELLOW: &str = "\x1b[33;1m";
+pub const RESET: &str = "\x1b[0m";
+
+fn format_micros(duration: u64) -> impl core::fmt::Display {
+    struct Duration(u64);
+    impl core::fmt::Display for Duration {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            let millis = self.0 / 1000;
+            write!(f, "{:01}.{:03}s", millis / 1000, millis % 1000)
+        }
+    }
+    Duration(duration)
+}
+
+async fn main(_device_tree: device_tree::DeviceTree<'static>) {
+    let tests = TESTS.array();
+
+    let timer = kernel::device::system_timer::SYSTEM_TIMER.get();
+    let start = timer.get_time();
+
+    println!("{GREEN}Running{RESET} {} tests", tests.len());
+
+    let mut passed = 0;
+    let mut failed = 0;
+
+    for test in TESTS.array() {
+        println!("{BOLD}=== Starting test{RESET} {}...", test.name);
+        let (tx, mut rx) = ringbuffer::channel();
+
+        let test_start = timer.get_time();
+
+        test.test.run(tx);
+        let result = rx.recv().await;
+
+        let test_end = timer.get_time();
+        let duration = format_micros(test_end - test_start);
+
+        if let Err(e) = result {
+            println!("{BOLD}==={RESET} {RED}failed{RESET} in {}: {}", duration, e);
+            failed += 1;
+        } else {
+            println!("{BOLD}==={RESET} {GREEN}passed{RESET} in {}", duration);
+            passed += 1;
+        }
+    }
+
+    let end = timer.get_time();
+    let elapsed = end - start;
+
+    println!("=== All tests completed");
+    println!("| Finished in {}", format_micros(elapsed));
+    println!(
+        "| Total {} tests, {} passed, {} failed",
+        passed + failed,
+        passed,
+        failed
+    );
+}

--- a/crates/kernel/examples/tests/mod.rs
+++ b/crates/kernel/examples/tests/mod.rs
@@ -1,0 +1,139 @@
+use core::error::Error;
+
+use alloc::boxed::Box;
+use alloc::sync::Arc;
+use kernel::{event, sync};
+
+#[derive(Debug)]
+struct AssertError(alloc::string::String);
+
+impl core::fmt::Display for AssertError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl core::error::Error for AssertError {}
+
+macro_rules! kassert_eq {
+    ($lhs:expr, $rhs:expr) => {{
+        let lhs = $lhs;
+        let rhs = $rhs;
+        if lhs != rhs {
+            let msg = alloc::format!(
+                "Assertion failed at at {}:{}: {:?}\n    lhs = {:?}\n    rhs = {:?}",
+                core::file!(), core::line!(),
+                stringify!($lhs != $rhs),
+                lhs, rhs,
+            );
+            return Err($crate::tests::AssertError(msg).into());
+        }
+    }};
+    ($lhs:expr, $rhs:expr, $context:literal $(, $($args:tt)*)?) => {{
+        let lhs = $lhs;
+        let rhs = $rhs;
+        if lhs != rhs {
+            let msg = alloc::format!(
+                "Assertion failed at at {}:{}: {:?}\n    lhs = {:?}\n    rhs = {:?}\n{}",
+                core::file!(), core::line!(),
+                stringify!($lhs != $rhs),
+                lhs, rhs,
+                format_args!($context, $($args)*),
+            );
+            return Err($crate::tests::AssertError(msg).into());
+        }
+    }};
+}
+
+test_case!(example_test);
+fn example_test() {
+    println!("Running test one");
+}
+
+// test_case!(async example_failure);
+// async fn example_failure() -> Result<(), &'static str> {
+//     println!("Running test two");
+//     sync::spin_sleep(500000);
+//     Err("hello!")
+// }
+
+test_case!(async async_barrier);
+async fn async_barrier() -> Result<(), Box<dyn Error + Send + Sync>> {
+    use core::sync::atomic::{AtomicU32, Ordering};
+
+    let count = 16;
+    let barrier = Arc::new(sync::Barrier::new(count + 1));
+    let reached = Arc::new(AtomicU32::new(0));
+
+    for i in 0..count {
+        let r = reached.clone();
+        let b: Arc<sync::Barrier> = barrier.clone();
+        event::task::spawn_async(async move {
+            println!("Starting thread {i}");
+
+            // TODO: non-spinning sleep
+            sync::spin_sleep(500_000);
+
+            println!("Ending thread {i}");
+
+            r.fetch_add(i, Ordering::SeqCst);
+            b.sync().await;
+        });
+    }
+
+    barrier.sync().await;
+
+    kassert_eq!(reached.load(Ordering::SeqCst), count * (count - 1) / 2);
+
+    Ok(())
+}
+
+// TODO: proper oneshot SPSC channel (single-use version of Future for cs439)
+fn spawn_thread<F, O>(f: F) -> kernel::ringbuffer::Receiver<2, O>
+where
+    F: FnOnce() -> O + Send + 'static,
+    O: Send + 'static,
+{
+    let (mut tx, rx) = kernel::ringbuffer::channel();
+    event::thread::thread(move || {
+        let res = f();
+        tx.try_send(res).map_err(|_| ()).unwrap();
+    });
+    rx
+}
+
+test_case!(async thread_barrier);
+async fn thread_barrier() -> Result<(), Box<dyn Error + Send + Sync>> {
+    use core::sync::atomic::{AtomicU32, Ordering};
+
+    let mut res = spawn_thread(move || {
+        let count = 32;
+        let barrier = Arc::new(sync::Barrier::new(count + 1));
+        let reached = Arc::new(AtomicU32::new(0));
+
+        for i in 0..count {
+            let r = reached.clone();
+            let b: Arc<sync::Barrier> = barrier.clone();
+            event::thread::thread(move || {
+                println!("Starting thread {i}");
+
+                // TODO: non-spinning sleep
+                sync::spin_sleep(500_000);
+
+                println!("Ending thread {i}");
+
+                r.fetch_add(i, Ordering::SeqCst);
+                b.sync_blocking();
+            });
+        }
+        barrier.sync_blocking();
+        println!("End of preemption test");
+
+        kassert_eq!(reached.load(Ordering::SeqCst), count * (count - 1) / 2);
+
+        Ok(())
+    });
+
+    let res = res.recv().await;
+    res
+}

--- a/crates/kernel/examples/tests/test_impl.rs
+++ b/crates/kernel/examples/tests/test_impl.rs
@@ -1,0 +1,167 @@
+use core::fmt::Display;
+
+use alloc::string::String;
+use event::task::spawn_async;
+use kernel::*;
+
+pub type TestResult = Result<(), String>;
+pub type TestSender = ringbuffer::Sender<2, TestResult>;
+
+pub trait TestImpl: Sync {
+    fn run(&'static self, channel: TestSender);
+}
+
+pub trait Failure {
+    fn as_error(&self) -> Option<&dyn Display>;
+}
+
+// impl<E: core::error::Error> Failure for Result<(), E> {
+//     fn as_error(&self) -> Option<&dyn Display> {
+//         self.as_ref().err().map(|e| e as &dyn Display)
+//     }
+// }
+impl Failure for Result<(), &'static str> {
+    fn as_error(&self) -> Option<&dyn Display> {
+        self.as_ref().err().map(|e| e as &dyn Display)
+    }
+}
+impl Failure for Result<(), alloc::boxed::Box<dyn core::error::Error>> {
+    fn as_error(&self) -> Option<&dyn Display> {
+        self.as_ref().err().map(|e| e as &dyn Display)
+    }
+}
+impl Failure for Result<(), alloc::boxed::Box<dyn core::error::Error + Send + Sync>> {
+    fn as_error(&self) -> Option<&dyn Display> {
+        self.as_ref().err().map(|e| e as &dyn Display)
+    }
+}
+
+impl Failure for () {
+    fn as_error(&self) -> Option<&dyn Display> {
+        None
+    }
+}
+
+impl<F, E> TestImpl for F
+where
+    F: Fn() -> E + Sync,
+    E: Failure,
+{
+    fn run(&'static self, mut channel: TestSender) {
+        spawn_async(async move {
+            let result = match self().as_error() {
+                Some(e) => Err(alloc::format!("{}", e)),
+                None => Ok(()),
+            };
+            channel.send(result).await;
+        });
+    }
+}
+
+pub trait AsyncFnCustomSend<Args> {
+    type Output;
+    type CallRefFuture: core::future::Future<Output = Self::Output> + Send;
+    fn call(&self, args: Args) -> Self::CallRefFuture;
+}
+
+impl<F, Fu> AsyncFnCustomSend<()> for F
+where
+    F: Fn() -> Fu,
+    Fu: core::future::Future + Send,
+{
+    type Output = Fu::Output;
+    type CallRefFuture = Fu;
+    fn call(&self, _args: ()) -> Self::CallRefFuture {
+        self()
+    }
+}
+
+pub struct AsyncImpl<F>(pub F);
+
+impl<F, E> TestImpl for AsyncImpl<F>
+where
+    F: AsyncFnCustomSend<(), Output = E> + Sync,
+    E: Failure + Send,
+{
+    fn run(&'static self, mut channel: TestSender) {
+        spawn_async(async move {
+            let result = self.0.call(()).await;
+            let result = match result.as_error() {
+                Some(e) => Err(alloc::format!("{}", e)),
+                None => Ok(()),
+            };
+            channel.send(result).await;
+        });
+    }
+}
+
+// pub fn check_impls<T, E>(f: T) -> T
+// where
+//     T: AsyncFnCustomSend<(), Output = E> + Sync,
+//     E: Failure + Send,
+// {
+//     f
+// }
+
+pub struct TestCase {
+    pub name: &'static str,
+    pub test: &'static dyn TestImpl,
+}
+
+pub struct StaticArray<TestCase> {
+    start: *const TestCase,
+    end: *const TestCase,
+}
+
+unsafe impl<'a, T: 'a> Send for StaticArray<T> where &'a [T]: Send {}
+unsafe impl<'a, T: 'a> Sync for StaticArray<T> where &'a [T]: Sync {}
+
+impl<T> StaticArray<T> {
+    pub fn array(&self) -> &'static [T] {
+        unsafe {
+            let len = (self.end).offset_from(self.start) as usize;
+            core::slice::from_raw_parts(self.start, len)
+        }
+    }
+}
+
+pub static TESTS: StaticArray<TestCase> = {
+    #[used]
+    #[link_section = ".test_array"]
+    static mut __ARRAY: [TestCase; 0] = [];
+    extern "Rust" {
+        #[link_name = "__test_array_start"]
+        static __START: [TestCase; 0];
+        #[link_name = "__test_array_end"]
+        static __END: [TestCase; 0];
+    }
+    assert!(size_of::<TestCase>() > 0);
+    StaticArray {
+        start: (&raw const __START).cast(),
+        end: (&raw const __END).cast(),
+    }
+};
+
+#[macro_export]
+macro_rules! test_case {
+    ($name:ident) => {
+        const _: () = {
+            #[used]
+            #[link_section = ".test_array"]
+            static TEST: $crate::test_impl::TestCase = $crate::test_impl::TestCase {
+                name: ::core::stringify!($name),
+                test: &$name as &dyn $crate::test_impl::TestImpl,
+            };
+        };
+    };
+    (async $name:ident) => {
+        const _: () = {
+            #[used]
+            #[link_section = ".test_array"]
+            static TEST: $crate::test_impl::TestCase = $crate::test_impl::TestCase {
+                name: ::core::stringify!($name),
+                test: &$crate::test_impl::AsyncImpl($name) as &dyn $crate::test_impl::TestImpl,
+            };
+        };
+    };
+}

--- a/crates/kernel/script.ld
+++ b/crates/kernel/script.ld
@@ -44,13 +44,22 @@ SECTIONS {
         *(.text*)
     } :segment_code
 
-    .rodata : ALIGN(8) { *(.rodata*) } :segment_code
-
     . = ALIGN(PAGE_SIZE);
     __code_end = .;
 
     __data_start = .;
-    .data : { *(.data) *(.data.*) } :segment_data
+    .rodata : ALIGN(8) { *(.rodata*) } :segment_data
+    .dataaa : ALIGN(8) {
+        *(.data)
+        *(.data.*)
+    } :segment_data
+
+    .test_array : ALIGN(8) {
+        __test_array_start = .;
+        // KEEP is a workaround for #[used(linker)] being unstable
+        KEEP(*(.test_array))
+        __test_array_end = .;
+    } :segment_data
 
     .bss (NOLOAD) : ALIGN(16) {
         __bss_start = .;

--- a/crates/kernel/src/runtime.rs
+++ b/crates/kernel/src/runtime.rs
@@ -21,6 +21,12 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
             info.message()
         );
     }
+
     // TODO: write error message to a fixed location in memory and reset?
+    {
+        // Shut down the system
+        let mut watchdog = crate::device::WATCHDOG.get().lock();
+        unsafe { watchdog.reset(63) };
+    }
     halt();
 }


### PR DESCRIPTION
This sets up a very basic kernel testing harness, which will run tests in series in a kernel binary; see `crates/kernel/examples/tests/mod.rs` for example tests.

There is currently no integration with the host system, but it would be straightforward to write a host-side script to check for the final number of passing/failing tests.  (Or a cargo test with harness=false, if it's possible to have that build for the host system.)

This also changes the panic behavior to shut down the system, rather than just spinning on the current thread/execution context.