### PR TITLE
Disable blocking methods in syscall handlers (which are non-preemptible)

### DIFF
--- a/crates/kernel/src/event/async_handler.rs
+++ b/crates/kernel/src/event/async_handler.rs
@@ -102,7 +102,7 @@ where
                 // The handler yielded; suspend the current thread, and set
                 // up the future to reschedule the thread when it finishes.
                 let thread = unsafe { &mut *future.data.thread.get() }.as_mut().unwrap();
-                unsafe { thread.save_context(ctx.into()) };
+                unsafe { thread.save_context(ctx.into(), thread.is_kernel_thread()) };
 
                 let woken = task::TASKS.return_task(task_id, task::Task::new(future));
                 if woken {

--- a/crates/kernel/src/event/exceptions.rs
+++ b/crates/kernel/src/event/exceptions.rs
@@ -299,7 +299,7 @@ unsafe extern "C" fn exception_handler_user(
 
                 let thread = CORES.with_current(|core| core.thread.take());
                 let mut thread = thread.expect("usermode syscall without active thread");
-                unsafe { thread.save_context(ctx.into()) };
+                unsafe { thread.save_context(ctx.into(), false) };
                 unsafe { deschedule_thread(DescheduleAction::FreeThread, Some(thread)) }
             }
         }

--- a/crates/kernel/src/syscall/proc.rs
+++ b/crates/kernel/src/syscall/proc.rs
@@ -10,7 +10,7 @@ pub unsafe fn sys_shutdown(_ctx: &mut Context) -> *mut Context {
 pub unsafe fn sys_exit(ctx: &mut Context) -> *mut Context {
     let thread = CORES.with_current(|core| core.thread.take());
     let mut thread = thread.expect("usermode syscall without active thread");
-    unsafe { thread.save_context(ctx.into()) };
+    unsafe { thread.save_context(ctx.into(), false) };
     unsafe { deschedule_thread(DescheduleAction::FreeThread, Some(thread)) }
 }
 

--- a/crates/kernel/src/syscall/sync.rs
+++ b/crates/kernel/src/syscall/sync.rs
@@ -3,6 +3,6 @@ use crate::event::context::{deschedule_thread, Context, DescheduleAction, CORES}
 pub unsafe fn sys_yield(ctx: &mut Context) -> *mut Context {
     let thread = CORES.with_current(|core| core.thread.take());
     let mut thread = thread.expect("usermode syscall without active thread");
-    unsafe { thread.save_context(ctx.into()) };
+    unsafe { thread.save_context(ctx.into(), false) };
     unsafe { deschedule_thread(DescheduleAction::Yield, Some(thread)) }
 }


### PR DESCRIPTION
This also fixes the checks in the timer interrupt handler, which were attempting to prevent this issue but were also unintentionally disabling preemption from user-mode.  (When coming from user-mode, the saved sp in context points to the kernel stack.)