### PR TITLE
Fix fault in exec when updating user sp without yielding

### DIFF
--- a/crates/kernel/src/event/context.rs
+++ b/crates/kernel/src/event/context.rs
@@ -76,7 +76,11 @@ unsafe impl Sync for AllCores {}
 #[repr(C)]
 pub struct Context {
     pub regs: [usize; 31],
-    pub sp: usize,
+    /// Note: don't use this, use a helper method on HandlerContext
+    /// or an equivalent.  (This will always resolve to the kernel sp,
+    /// even for user threads.)
+    #[deprecated = "Don't use the context sp directly; use get_sp/set_sp"]
+    pub kernel_sp: usize,
     pub link_reg: usize,
     pub spsr: usize,
 }

--- a/crates/kernel/src/event/mod.rs
+++ b/crates/kernel/src/event/mod.rs
@@ -84,12 +84,14 @@ pub unsafe fn timer_handler(ctx: &mut Context) -> *mut Context {
     if ctx.current_el() == context::ExceptionLevel::EL1 {
         let stacks = &raw const crate::arch::boot::STACKS;
         let ptr_range = stacks as usize..stacks.wrapping_add(1) as usize;
+        #[allow(deprecated)]
+        let kernel_sp = ctx.kernel_sp;
         assert!(
-            !ptr_range.contains(&ctx.sp),
+            !ptr_range.contains(&kernel_sp),
             "Attempted to preempt core on kernel stack; kernel-thread: {:?}, el: {:?}, sp: {:?}",
             thread.is_kernel_thread(),
             ctx.current_el(),
-            ctx.sp
+            kernel_sp
         );
     }
 

--- a/crates/kernel/src/syscall/exec.rs
+++ b/crates/kernel/src/syscall/exec.rs
@@ -119,19 +119,13 @@ pub unsafe fn sys_execve_fd(ctx: &mut Context) -> *mut Context {
         {
             let mut regs = context.regs();
             regs.regs = [0; 31];
-            regs.sp = 0;
             regs.link_reg = user_entry as usize;
             regs.spsr = 0b0000; // TODO: standardize initial SPSR values
         }
-        let thread = context.cur_thread_mut().as_mut().unwrap();
-        let user = thread.user_regs.as_mut().unwrap();
-        user.sp_el0 = user_sp;
+        context.set_sp(user_sp);
 
         // TODO: initial stack setup
         // (argc, argv, envp, auxv)
-
-        // TODO: debug why this causes a data abort if it never yields
-        crate::event::task::yield_future().await;
 
         context.resume_final()
     })


### PR DESCRIPTION
This also renames the `sp` in `Context` to `kernel_sp`, and marks it `#[deprecated]` (as a hack to make it trigger warnings), since it's almost never what you actually want to use.

(This is the second bug I've added by misusing the Context's `sp`, which is why I'm including a number of mitigations to help prevent future misuse.)