### PR TITLE
Implement wait and exit codes

### DIFF
--- a/crates/init/example.rs
+++ b/crates/init/example.rs
@@ -210,11 +210,10 @@ fn main(_chan: ulib::sys::ChannelDesc) {
         // };
         // send_block(chan, &msg, line.as_bytes());
 
-        for _ in 0..100 {
-            // TODO: this is a hack to prevent concurrent access to stdout...
-            unsafe { ulib::sys::yield_() }
+        if line == "exit" {
+            break;
         }
     }
 
-    unsafe { ulib::sys::exit() };
+    unsafe { ulib::sys::exit(15) };
 }

--- a/crates/kernel/src/process.rs
+++ b/crates/kernel/src/process.rs
@@ -2,6 +2,7 @@ use alloc::boxed::Box;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 
+use crate::sync::once_cell::BlockingOnceCell;
 use crate::sync::SpinLock;
 
 pub mod fd;
@@ -17,10 +18,15 @@ pub struct FileDescriptorList {
     pub desc: Vec<Option<fd::ArcFd>>,
 }
 
+pub struct ExitStatus {
+    pub status: u32,
+}
+
 pub struct Process {
     pub page_table: UserPageTable,
     pub root: Option<fd::ArcFd>,
     pub file_descriptors: SpinLock<FileDescriptorList>,
+    pub exit_code: Arc<BlockingOnceCell<ExitStatus>>,
 }
 
 impl Process {
@@ -38,6 +44,7 @@ impl Process {
             page_table,
             root: None,
             file_descriptors: SpinLock::new(FileDescriptorList { desc: Vec::new() }),
+            exit_code: Arc::new(BlockingOnceCell::new()),
         }
     }
 

--- a/crates/kernel/src/sync.rs
+++ b/crates/kernel/src/sync.rs
@@ -4,6 +4,7 @@ mod condvar;
 pub mod handler_table;
 pub mod init;
 pub mod lock;
+pub mod once_cell;
 pub mod per_core;
 pub mod time;
 

--- a/crates/kernel/src/sync/once_cell.rs
+++ b/crates/kernel/src/sync/once_cell.rs
@@ -1,0 +1,48 @@
+use core::cell::UnsafeCell;
+use core::mem::MaybeUninit;
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use super::{Condvar, SpinLock};
+
+pub struct BlockingOnceCell<T> {
+    condvar: Condvar,
+    ready_skip: AtomicBool,
+    ready: SpinLock<bool>,
+    data: UnsafeCell<MaybeUninit<T>>,
+}
+
+impl<T> BlockingOnceCell<T> {
+    pub fn new() -> Self {
+        BlockingOnceCell {
+            condvar: Condvar::new(),
+            ready_skip: AtomicBool::new(false),
+            ready: SpinLock::new(false),
+            data: UnsafeCell::new(MaybeUninit::uninit()),
+        }
+    }
+
+    pub fn set(&self, value: T) {
+        let mut guard = self.ready.lock();
+        assert!(!*guard);
+        unsafe { (*self.data.get()).write(value) };
+        *guard = true;
+        drop(guard);
+        self.ready_skip.store(true, Ordering::Release);
+        self.condvar.notify_all();
+    }
+
+    pub async fn get(&self) -> &T {
+        // TODO: avoid the lock?
+        if self.ready_skip.load(Ordering::Acquire) {
+            return unsafe { (&*self.data.get()).assume_init_ref() };
+        }
+        let guard = self.ready.lock();
+        self.condvar
+            .wait_while(guard, |ready| *ready == false)
+            .await;
+        unsafe { (&*self.data.get()).assume_init_ref() }
+    }
+}
+
+unsafe impl<T: Send> Send for BlockingOnceCell<T> {}
+unsafe impl<T: Sync> Sync for BlockingOnceCell<T> {}

--- a/crates/kernel/src/syscall/mod.rs
+++ b/crates/kernel/src/syscall/mod.rs
@@ -29,6 +29,7 @@ pub unsafe fn register_syscalls() {
 
         register_syscall_handler(15, file::sys_openat);
         register_syscall_handler(16, exec::sys_execve_fd);
+        register_syscall_handler(17, proc::sys_wait);
     }
 }
 

--- a/crates/kernel/src/syscall/proc.rs
+++ b/crates/kernel/src/syscall/proc.rs
@@ -1,6 +1,10 @@
 use alloc::sync::Arc;
 
+use crate::event::async_handler::{run_async_handler, HandlerContext};
 use crate::event::context::{deschedule_thread, Context, DescheduleAction, CORES};
+use crate::process::fd::{self, FileDescriptor};
+use crate::process::ExitStatus;
+use crate::sync::once_cell::BlockingOnceCell;
 use crate::{event, event::thread, shutdown};
 
 pub unsafe fn sys_shutdown(_ctx: &mut Context) -> *mut Context {
@@ -10,6 +14,16 @@ pub unsafe fn sys_shutdown(_ctx: &mut Context) -> *mut Context {
 pub unsafe fn sys_exit(ctx: &mut Context) -> *mut Context {
     let thread = CORES.with_current(|core| core.thread.take());
     let mut thread = thread.expect("usermode syscall without active thread");
+
+    let status = ctx.regs[0];
+
+    // TODO: split exit into process exit and thread exit?
+    // TODO: ensure processes can't exit without setting this
+    let exit_code = &thread.process.as_ref().unwrap().exit_code;
+    exit_code.set(crate::process::ExitStatus {
+        status: status as u32,
+    });
+
     unsafe { thread.save_context(ctx.into(), false) };
     unsafe { deschedule_thread(DescheduleAction::FreeThread, Some(thread)) }
 }
@@ -31,12 +45,21 @@ pub unsafe fn sys_spawn(ctx: &mut Context) -> *mut Context {
     });
     let old_process = cur_process.unwrap();
 
+    let wait_fd;
     let process;
+
     if flags == 1 {
         // Same process, shared memory
         process = old_process;
+        wait_fd = (-1isize) as usize;
     } else {
         process = Arc::new(old_process.fork());
+        let descriptor = WaitFd(process.exit_code.clone());
+        let fd = old_process
+            .file_descriptors
+            .lock()
+            .insert(Arc::new(descriptor));
+        wait_fd = fd;
     }
 
     println!(
@@ -47,5 +70,65 @@ pub unsafe fn sys_spawn(ctx: &mut Context) -> *mut Context {
     user_thread.context.as_mut().unwrap().regs[0] = user_x0;
     event::SCHEDULER.add_task(event::Event::ScheduleThread(user_thread));
 
+    ctx.regs[0] = wait_fd;
     ctx
+}
+
+/// syscall wait(fd: u32) -> i64
+pub unsafe fn sys_wait(ctx: &mut Context) -> *mut Context {
+    let fd = ctx.regs[0];
+
+    run_async_handler(ctx, async move |mut context: HandlerContext<'_>| {
+        let proc = context.cur_process().unwrap();
+
+        let file = proc.file_descriptors.lock().get(fd).cloned();
+        let Some(file) = file else {
+            context.regs().regs[0] = i64::from(-1) as usize;
+            return context.resume_final();
+        };
+        let Some(file) = file.as_any().downcast_ref::<WaitFd>() else {
+            context.regs().regs[0] = i64::from(-1) as usize;
+            return context.resume_final();
+        };
+
+        let status = file.0.get().await;
+
+        context.regs().regs[0] = status.status as usize;
+        context.resume_final()
+    })
+}
+
+struct WaitFd(Arc<BlockingOnceCell<ExitStatus>>);
+
+impl FileDescriptor for WaitFd {
+    fn is_same_file(&self, other: &dyn FileDescriptor) -> bool {
+        let other = other.as_any().downcast_ref::<Self>();
+        other.map(|o| Arc::ptr_eq(&self.0, &o.0)).unwrap_or(true)
+    }
+    fn kind(&self) -> fd::FileKind {
+        fd::FileKind::Other
+    }
+    fn read<'a>(
+        &'a self,
+        _offset: u64,
+        _buf: &'a mut [u8],
+    ) -> fd::SmallFuture<'a, fd::FileDescResult> {
+        fd::boxed_future(async move { Err(1).into() })
+    }
+    fn write<'a>(
+        &'a self,
+        _offset: u64,
+        _buf: &'a [u8],
+    ) -> fd::SmallFuture<'a, fd::FileDescResult> {
+        fd::boxed_future(async move { Err(1).into() })
+    }
+    fn size<'a>(&'a self) -> fd::SmallFuture<'a, fd::FileDescResult> {
+        fd::boxed_future(async move { Err(1).into() })
+    }
+    fn mmap_page(&self, _offset: u64) -> fd::SmallFuture<Option<fd::FileDescResult>> {
+        fd::boxed_future(async move { None })
+    }
+    fn as_any(&self) -> &dyn core::any::Any {
+        self
+    }
 }

--- a/crates/ulib/src/runtime.rs
+++ b/crates/ulib/src/runtime.rs
@@ -5,7 +5,7 @@ unsafe extern "Rust" {
 #[unsafe(no_mangle)]
 extern "C" fn _start(x0: usize) -> ! {
     unsafe { main(crate::sys::ChannelDesc(x0 as u32)) };
-    unsafe { crate::sys::exit() };
+    unsafe { crate::sys::exit(0) };
     unsafe { core::arch::asm!("udf #2", options(noreturn)) }
 }
 

--- a/crates/ulib/src/sys.rs
+++ b/crates/ulib/src/sys.rs
@@ -29,8 +29,8 @@ struct Channels(usize, usize);
 
 syscall!(1 => pub fn shutdown());
 syscall!(3 => pub fn yield_());
-syscall!(5 => pub fn spawn(pc: usize, sp: usize, x0: usize, flags: usize));
-syscall!(6 => pub fn exit());
+syscall!(5 => pub fn spawn(pc: usize, sp: usize, x0: usize, flags: usize) -> usize);
+syscall!(6 => pub fn exit(status: usize));
 
 syscall!(7 => fn _channel() -> Channels);
 pub fn channel() -> (ChannelDesc, ChannelDesc) {
@@ -123,3 +123,5 @@ syscall!(16 => pub fn execve_fd(
     envc: usize,
     envp: *const ArgStr,
 ) -> isize);
+
+syscall!(17 => pub fn wait(fd: usize) -> isize);


### PR DESCRIPTION
`spawn` now returns a file descriptor for the child process, which can be passed to `wait` to wait until the child exits.

This doesn't introduce any sort of PIDs, though, so a process can only be waited on by its parent or its parent's children.  (Well, or anyone with the fd, but that's currently limited to the parent and its future children.)