### PR TITLE
Port channels to use file descriptors

### DIFF
--- a/crates/init/src/main.rs
+++ b/crates/init/src/main.rs
@@ -6,13 +6,15 @@ extern crate ulib;
 
 mod runtime;
 
-fn spawn_elf(fd: usize) -> usize {
+use ulib::sys::FileDesc;
+
+fn spawn_elf(fd: FileDesc) -> Result<FileDesc, usize> {
     let current_stack = current_sp();
     let target_pc = exec_child as usize;
     let arg = fd;
 
-    let wait_fd = unsafe { ulib::sys::spawn(target_pc, current_stack, arg, 0) };
-    wait_fd as usize
+    let wait_fd = unsafe { ulib::sys::spawn(target_pc, current_stack, arg as usize, 0) };
+    wait_fd
 }
 
 fn current_sp() -> usize {
@@ -21,17 +23,13 @@ fn current_sp() -> usize {
     sp
 }
 
-extern "C" fn exec_child(fd: usize) -> ! {
-    let argc = 0;
+extern "C" fn exec_child(fd: FileDesc) -> ! {
     let flags = 0;
-    let argv = core::ptr::null();
-    let envc = 0;
-    let envp = core::ptr::null();
-
-    let res = unsafe { ulib::sys::execve_fd(fd, flags, argc, argv, envc, envp) };
-    println!("Execve failed: {}", res);
-    unsafe { ulib::sys::exit(1) };
-    unsafe { core::arch::asm!("udf #2", options(noreturn)) }
+    let args = &[];
+    let env = &[];
+    let res = unsafe { ulib::sys::execve_fd(fd, flags, args, env) };
+    println!("Execve failed: {:?}", res);
+    ulib::sys::exit(1);
 }
 
 #[unsafe(no_mangle)]
@@ -40,14 +38,12 @@ pub extern "C" fn main() {
 
     let root_fd = 3;
     let path = b"example.elf";
-    let file = unsafe { ulib::sys::openat(root_fd, path.len(), path.as_ptr(), 0, 0) };
-    assert!(file >= 0);
-    let file = file as usize;
+    let file = ulib::sys::openat(root_fd, path, 0, 0).unwrap();
 
     // TODO: channels
-    let child = spawn_elf(file);
+    let child = spawn_elf(file).unwrap();
 
-    let status = unsafe { ulib::sys::wait(child) };
+    let status = ulib::sys::wait(child).unwrap();
 
     println!("Child exited with status {}", status);
 
@@ -74,8 +70,7 @@ pub extern "C" fn main() {
     //     }
     // }
 
-    unsafe { ulib::sys::shutdown() };
-    unreachable!();
+    ulib::sys::shutdown();
 }
 
 #[macro_use]

--- a/crates/kernel/examples/user.rs
+++ b/crates/kernel/examples/user.rs
@@ -22,9 +22,9 @@ extern "Rust" fn kernel_main(_device_tree: device_tree::DeviceTree) {
     let (_stdio, mut stdin_tx, mut stdout_rx) = {
         let (stdin_tx, stdin_rx) = ringbuffer::channel();
         let (stdout_tx, stdout_rx) = ringbuffer::channel();
-        let stdio_chan = syscall::channel::alloc_obj(syscall::channel::Object::Channel {
-            send: stdout_tx,
-            recv: stdin_rx,
+        let stdio_chan = Arc::new(syscall::channel::Channel {
+            send: sync::SpinLock::new(stdout_tx),
+            recv: sync::SpinLock::new(stdin_rx),
         });
         (stdio_chan, stdin_tx, stdout_rx)
     };

--- a/crates/kernel/src/process.rs
+++ b/crates/kernel/src/process.rs
@@ -133,7 +133,7 @@ impl FileDescriptorList {
         idx
     }
     #[must_use]
-    pub fn close(&mut self, idx: usize) -> Option<fd::ArcFd> {
+    pub fn remove(&mut self, idx: usize) -> Option<fd::ArcFd> {
         match self.desc.get_mut(idx) {
             Some(slot) => slot.take(),
             None => None,

--- a/crates/kernel/src/syscall/file.rs
+++ b/crates/kernel/src/syscall/file.rs
@@ -47,7 +47,7 @@ pub unsafe fn sys_close(ctx: &mut Context) -> *mut Context {
     let proc = current_process().unwrap();
 
     let mut guard = proc.file_descriptors.lock();
-    if let Some(desc) = guard.close(fd) {
+    if let Some(desc) = guard.remove(fd) {
         // TODO: we should be careful about where/when fd destructors are run
         drop(desc);
 

--- a/crates/kernel/src/syscall/mod.rs
+++ b/crates/kernel/src/syscall/mod.rs
@@ -10,8 +10,6 @@ pub mod proc;
 pub mod sync;
 
 pub unsafe fn register_syscalls() {
-    channel::OBJECTS.lock().push(None);
-
     unsafe {
         register_syscall_handler(1, proc::sys_shutdown);
         register_syscall_handler(3, sync::sys_yield);

--- a/crates/ulib/src/lib.rs
+++ b/crates/ulib/src/lib.rs
@@ -9,8 +9,9 @@ pub struct Stdout;
 
 impl core::fmt::Write for Stdout {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
-        let _res = unsafe { sys::pwrite_all(1, s.as_bytes(), 0) };
-        Ok(())
+        sys::pwrite_all(1, s.as_bytes(), 0)
+            .map(|_| ())
+            .map_err(|_| core::fmt::Error)
     }
 }
 

--- a/crates/ulib/src/runtime.rs
+++ b/crates/ulib/src/runtime.rs
@@ -5,8 +5,7 @@ unsafe extern "Rust" {
 #[unsafe(no_mangle)]
 extern "C" fn _start(x0: usize) -> ! {
     unsafe { main(crate::sys::ChannelDesc(x0 as u32)) };
-    unsafe { crate::sys::exit(0) };
-    unsafe { core::arch::asm!("udf #2", options(noreturn)) }
+    crate::sys::exit(0);
 }
 
 #[cfg(not(test))]

--- a/crates/ulib/src/sys.rs
+++ b/crates/ulib/src/sys.rs
@@ -13,6 +13,15 @@ macro_rules! syscall {
     };
 }
 
+fn int_to_error(res: isize) -> Result<usize, usize> {
+    match res {
+        0.. => Ok(res.unsigned_abs()),
+        ..0 => Err(res.unsigned_abs()),
+    }
+}
+
+pub type FileDesc = u32;
+
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ChannelDesc(pub u32);
@@ -25,83 +34,34 @@ pub struct Message {
 }
 
 #[repr(C)]
-struct Channels(usize, usize);
-
-syscall!(1 => pub fn shutdown());
-syscall!(3 => pub fn yield_());
-syscall!(5 => pub fn spawn(pc: usize, sp: usize, x0: usize, flags: usize) -> usize);
-syscall!(6 => pub fn exit(status: usize));
-
-syscall!(7 => fn _channel() -> Channels);
-pub fn channel() -> (ChannelDesc, ChannelDesc) {
-    let res = unsafe { _channel() };
-    (ChannelDesc(res.0 as u32), ChannelDesc(res.1 as u32))
-}
-
-const FLAG_NO_BLOCK: usize = 1 << 0;
-
-syscall!(8 => pub fn _send(desc: ChannelDesc, msg: *const Message, buf: *const u8, buf_len: usize, flags: usize) -> isize);
-syscall!(9 => pub fn _recv(desc: ChannelDesc, msg: *mut Message, buf: *mut u8, buf_cap: usize, flags: usize) -> isize);
-
-pub fn send(desc: ChannelDesc, msg: &Message, buf: &[u8]) -> isize {
-    unsafe { _send(desc, msg, buf.as_ptr(), buf.len(), FLAG_NO_BLOCK) }
-}
-pub fn send_block(desc: ChannelDesc, msg: &Message, buf: &[u8]) -> isize {
-    unsafe { _send(desc, msg, buf.as_ptr(), buf.len(), 0) }
-}
-pub fn recv(desc: ChannelDesc, buf: &mut [u8]) -> Result<(isize, Message), isize> {
-    let mut msg = MaybeUninit::uninit();
-    let res = unsafe {
-        _recv(
-            desc,
-            msg.as_mut_ptr(),
-            buf.as_mut_ptr(),
-            buf.len(),
-            FLAG_NO_BLOCK,
-        )
-    };
-    if res >= 0 {
-        Ok((res, unsafe { msg.assume_init() }))
-    } else {
-        Err(res)
-    }
-}
-pub fn recv_block(desc: ChannelDesc, buf: &mut [u8]) -> Result<(usize, Message), isize> {
-    let mut msg = MaybeUninit::uninit();
-    let res = unsafe { _recv(desc, msg.as_mut_ptr(), buf.as_mut_ptr(), buf.len(), 0) };
-    if res >= 0 {
-        Ok((res as usize, unsafe { msg.assume_init() }))
-    } else {
-        Err(res)
-    }
-}
-
-syscall!(10 => pub fn pread(fd: usize, buf: *mut u8, buf_len: usize, offset: u64) -> isize);
-syscall!(11 => pub fn pwrite(fd: usize, buf: *const u8, buf_len: usize, offset: u64) -> isize);
-syscall!(12 => pub fn close(fd: usize) -> isize);
-syscall!(13 => pub fn dup3(old_fd: usize, new_fd: usize, flags: usize) -> isize);
-syscall!(14 => pub fn pipe(flags: usize) -> PipeValues);
+pub struct Channels(pub usize, pub usize);
 
 #[repr(C)]
-pub struct PipeValues([isize; 2]);
+pub struct PipeValues(pub [isize; 2]);
 
-pub unsafe fn pwrite_all(fd: usize, buf: &[u8], offset: u64) -> isize {
-    let mut remaining = buf;
-    let mut written = 0;
-    while !remaining.is_empty() {
-        match unsafe { pwrite(fd, remaining.as_ptr(), remaining.len(), offset + written) } {
-            i @ (..=-1) => return i,
-            i @ (1..) => {
-                written += i as u64;
-                remaining = &remaining[i as usize..];
-            }
-            0 => return -1, // EOF
-        }
-    }
-    written as isize
+#[repr(C)]
+pub struct ArgStr {
+    pub len: usize,
+    pub ptr: *const u8,
 }
 
-syscall!(15 => pub fn openat(
+syscall!(1 => pub fn sys_shutdown());
+syscall!(3 => pub fn sys_yield());
+syscall!(5 => pub fn sys_spawn(pc: usize, sp: usize, x0: usize, flags: usize) -> isize);
+syscall!(6 => pub fn sys_exit(status: usize));
+
+syscall!(7 => pub fn sys_channel() -> Channels);
+syscall!(8 => pub fn sys_send(desc: usize, msg: *const Message, buf: *const u8, buf_len: usize, flags: usize) -> isize);
+syscall!(9 => pub fn sys_recv(desc: usize, msg: *mut Message, buf: *mut u8, buf_cap: usize, flags: usize) -> isize);
+
+syscall!(10 => pub fn sys_pread(fd: usize, buf: *mut u8, buf_len: usize, offset: u64) -> isize);
+syscall!(11 => pub fn sys_pwrite(fd: usize, buf: *const u8, buf_len: usize, offset: u64) -> isize);
+
+syscall!(12 => pub fn sys_close(fd: usize) -> isize);
+syscall!(13 => pub fn sys_dup3(old_fd: usize, new_fd: usize, flags: usize) -> isize);
+syscall!(14 => pub fn sys_pipe(flags: usize) -> PipeValues);
+
+syscall!(15 => pub fn sys_openat(
     dir_fd: usize,
     path_len: usize,
     path_ptr: *const u8,
@@ -109,13 +69,7 @@ syscall!(15 => pub fn openat(
     mode: usize,
 ) -> isize);
 
-#[repr(C)]
-pub struct ArgStr {
-    len: usize,
-    ptr: *const u8,
-}
-
-syscall!(16 => pub fn execve_fd(
+syscall!(16 => pub fn sys_execve_fd(
     fd: usize,
     flags: usize,
     argc: usize,
@@ -124,4 +78,141 @@ syscall!(16 => pub fn execve_fd(
     envp: *const ArgStr,
 ) -> isize);
 
-syscall!(17 => pub fn wait(fd: usize) -> isize);
+syscall!(17 => pub fn sys_wait(fd: usize) -> isize);
+
+/* * * * * * * * * * * * * * * * * * * */
+/* Syscall wrappers                    */
+/* * * * * * * * * * * * * * * * * * * */
+
+const FLAG_NO_BLOCK: usize = 1 << 0;
+
+pub fn channel() -> (ChannelDesc, ChannelDesc) {
+    let res = unsafe { sys_channel() };
+    (ChannelDesc(res.0 as u32), ChannelDesc(res.1 as u32))
+}
+
+pub fn send(desc: ChannelDesc, msg: &Message, buf: &[u8], flags: usize) -> isize {
+    unsafe { sys_send(desc.0 as usize, msg, buf.as_ptr(), buf.len(), flags) }
+}
+pub fn send_block(desc: ChannelDesc, msg: &Message, buf: &[u8]) -> isize {
+    send(desc, msg, buf, 0)
+}
+pub fn send_nonblock(desc: ChannelDesc, msg: &Message, buf: &[u8]) -> isize {
+    send(desc, msg, buf, FLAG_NO_BLOCK)
+}
+
+pub fn recv(desc: ChannelDesc, buf: &mut [u8], flags: usize) -> Result<(usize, Message), isize> {
+    let mut msg = MaybeUninit::uninit();
+    let res = unsafe {
+        sys_recv(
+            desc.0 as usize,
+            msg.as_mut_ptr(),
+            buf.as_mut_ptr(),
+            buf.len(),
+            flags,
+        )
+    };
+    if res >= 0 {
+        Ok((res as usize, unsafe { msg.assume_init() }))
+    } else {
+        Err(res)
+    }
+}
+pub fn recv_block(desc: ChannelDesc, buf: &mut [u8]) -> Result<(usize, Message), isize> {
+    recv(desc, buf, 0)
+}
+pub fn recv_nonblock(desc: ChannelDesc, buf: &mut [u8]) -> Result<(usize, Message), isize> {
+    recv(desc, buf, FLAG_NO_BLOCK)
+}
+
+pub fn shutdown() -> ! {
+    unsafe { sys_shutdown() };
+    unsafe { core::arch::asm!("udf #2", options(noreturn)) }
+}
+
+pub fn yield_() {
+    unsafe { sys_yield() }
+}
+
+pub unsafe fn spawn(pc: usize, sp: usize, x0: usize, flags: usize) -> Result<FileDesc, usize> {
+    let res = unsafe { sys_spawn(pc, sp, x0, flags) };
+    int_to_error(res).map(|fd| fd as FileDesc)
+}
+
+pub fn exit(status: usize) -> ! {
+    unsafe { sys_exit(status) };
+    unsafe { core::arch::asm!("udf #2", options(noreturn)) }
+}
+
+pub fn pread(fd: FileDesc, buf: &mut [u8], offset: u64) -> Result<usize, usize> {
+    let res = unsafe { sys_pread(fd as usize, buf.as_mut_ptr(), buf.len(), offset) };
+    int_to_error(res)
+}
+
+pub fn pwrite(fd: FileDesc, buf: &[u8], offset: u64) -> Result<usize, usize> {
+    let res = unsafe { sys_pwrite(fd as usize, buf.as_ptr(), buf.len(), offset) };
+    int_to_error(res)
+}
+
+pub fn pwrite_all(fd: FileDesc, buf: &[u8], offset: u64) -> Result<usize, usize> {
+    let mut remaining = buf;
+    let mut written = 0;
+    while !remaining.is_empty() {
+        let res = pwrite(fd, remaining, offset + written as u64)?;
+        if res == 0 {
+            return Err(1); // EOF
+        }
+        written += res;
+        remaining = &remaining[res..];
+    }
+    Ok(written)
+}
+
+pub fn close(fd: FileDesc) -> Result<(), usize> {
+    let res = unsafe { sys_close(fd as usize) };
+    int_to_error(res).map(|_| ())
+}
+
+pub fn dup3(old_fd: FileDesc, new_fd: FileDesc, flags: usize) -> Result<FileDesc, usize> {
+    let res = unsafe { sys_dup3(old_fd as usize, new_fd as usize, flags) };
+    int_to_error(res).map(|fd| fd as FileDesc)
+}
+
+pub fn pipe(flags: usize) -> Result<(FileDesc, FileDesc), usize> {
+    let res = unsafe { sys_pipe(flags) };
+    let [rx, tx] = res.0;
+    if rx < 0 {
+        Err(rx.unsigned_abs())
+    } else {
+        Ok((rx.unsigned_abs() as FileDesc, tx.unsigned_abs() as FileDesc))
+    }
+}
+
+pub fn openat(dir_fd: FileDesc, path: &[u8], flags: usize, mode: usize) -> Result<FileDesc, usize> {
+    let res = unsafe { sys_openat(dir_fd as usize, path.len(), path.as_ptr(), flags, mode) };
+    int_to_error(res).map(|fd| fd as FileDesc)
+}
+
+pub unsafe fn execve_fd(
+    fd: FileDesc,
+    flags: usize,
+    args: &[ArgStr],
+    env: &[ArgStr],
+) -> Result<(), usize> {
+    let res = unsafe {
+        sys_execve_fd(
+            fd as usize,
+            flags,
+            args.len(),
+            args.as_ptr(),
+            env.len(),
+            env.as_ptr(),
+        )
+    };
+    int_to_error(res).map(|_| ())
+}
+
+pub fn wait(fd: FileDesc) -> Result<usize, usize> {
+    let res = unsafe { sys_wait(fd as usize) };
+    int_to_error(res)
+}


### PR DESCRIPTION
The channels still don't have proper MPMC queues internally, but they now allow transferring ownership of file descriptors between processes.