### PR TITLE
Async timer APIs

### DIFF
--- a/crates/kernel/examples/async.rs
+++ b/crates/kernel/examples/async.rs
@@ -19,14 +19,13 @@ extern "Rust" fn kernel_main(_device_tree: device_tree::DeviceTree) {
             let b: alloc::sync::Arc<sync::Barrier> = barrier.clone();
             task::spawn_async(async move {
                 println!("Starting thread {i}");
-                // TODO: non-spinning sleep
-                sync::spin_sleep(500_000);
+                sync::time::sleep(500_000).await;
                 println!("Ending thread {i}");
                 b.sync().await;
             });
         }
         barrier.sync().await;
-        println!("End of preemption test");
+        println!("End of async sleep scheduling test");
         shutdown();
     });
 

--- a/crates/kernel/examples/async_timer.rs
+++ b/crates/kernel/examples/async_timer.rs
@@ -1,0 +1,45 @@
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+extern crate kernel;
+
+use alloc::sync::Arc;
+use event::task::spawn_async;
+use kernel::*;
+use sync::time::interval;
+use sync::Barrier;
+
+#[no_mangle]
+extern "Rust" fn kernel_main(_device_tree: device_tree::DeviceTree) {
+    println!("| starting kernel_main");
+    crate::event::task::spawn_async(async move {
+        main().await;
+    });
+    crate::event::thread::stop();
+}
+
+async fn main() {
+    let total_time = 5000;
+    let count = 64;
+    let barrier = Arc::new(Barrier::new(count + 1));
+
+    for i in 0..count as u64 {
+        let b: Arc<Barrier> = barrier.clone();
+        spawn_async(async move {
+            let period = (total_time / (i + 1)).max(1);
+            let steps = total_time / period;
+            let mut interval = interval(period * 1000);
+            println!("Task {i} started with period of {period}");
+            for _ in 0..steps {
+                interval.tick().await;
+            }
+            println!("Task {i} done");
+            b.sync().await;
+        });
+    }
+
+    barrier.sync().await;
+    println!("End of async sleep scheduling test");
+    shutdown();
+}

--- a/crates/kernel/examples/hid.rs
+++ b/crates/kernel/examples/hid.rs
@@ -5,14 +5,20 @@ extern crate alloc;
 extern crate kernel;
 
 use device::usb::mouse::{MouseEvent, MOUSE_EVENTS};
-use kernel::device::system_timer::micro_delay;
 use kernel::device::usb::keyboard::Key;
 use kernel::*;
+use sync::time::sleep;
 
 #[no_mangle]
 extern "Rust" fn kernel_main(_device_tree: device_tree::DeviceTree) {
     println!("| starting kernel_main");
+    crate::event::task::spawn_async(async move {
+        main().await;
+    });
+    crate::event::thread::stop();
+}
 
+async fn main() {
     //Basic mouse & keyboard test
     let mut cur_x = 0;
     let mut cur_y = 0;
@@ -51,6 +57,6 @@ extern "Rust" fn kernel_main(_device_tree: device_tree::DeviceTree) {
                 }
             }
         }
-        micro_delay(10000);
+        sleep(10000).await;
     }
 }

--- a/crates/kernel/examples/keyboard.rs
+++ b/crates/kernel/examples/keyboard.rs
@@ -4,21 +4,27 @@
 extern crate alloc;
 extern crate kernel;
 
-use kernel::device::system_timer::micro_delay;
 use kernel::*;
+use sync::time::sleep;
 
 #[no_mangle]
 extern "Rust" fn kernel_main(_device_tree: device_tree::DeviceTree) {
     println!("| starting kernel_main");
+    crate::event::task::spawn_async(async move {
+        main().await;
+    });
+    crate::event::thread::stop();
+}
 
+async fn main() {
     // Basic keyboard test
     loop {
-        micro_delay(10000);
         while let Some(event) = device::usb::keyboard::KEY_EVENTS.poll() {
             match event.pressed {
                 true => println!("Key {:?} ({}) pressed", event.key, event.code),
                 false => println!("Key {:?} ({}) released", event.key, event.code),
             }
         }
+        sleep(10000).await;
     }
 }

--- a/crates/kernel/examples/load.rs
+++ b/crates/kernel/examples/load.rs
@@ -1,0 +1,26 @@
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+extern crate kernel;
+
+use event::task::yield_future;
+use kernel::event::{task, thread};
+use kernel::*;
+
+#[no_mangle]
+extern "Rust" fn kernel_main(_device_tree: device_tree::DeviceTree) {
+    println!("| running load test");
+
+    task::spawn_async(async move {
+        for _ in 0..(1 << 10) {
+            task::spawn_async(async move {
+                loop {
+                    yield_future().await;
+                }
+            });
+        }
+    });
+
+    thread::stop();
+}

--- a/crates/kernel/examples/user.rs
+++ b/crates/kernel/examples/user.rs
@@ -137,7 +137,7 @@ extern "Rust" fn kernel_main(_device_tree: device_tree::DeviceTree) {
 
     let user_thread = unsafe { thread::Thread::new_user(Arc::new(process), user_sp, user_entry) };
 
-    event::SCHEDULER.add_task(event::Event::ScheduleThread(user_thread));
+    event::SCHEDULER.add_task(event::Event::schedule_thread(user_thread));
 
     thread::stop();
 }

--- a/crates/kernel/examples/vsync.rs
+++ b/crates/kernel/examples/vsync.rs
@@ -8,9 +8,15 @@ use device::{discover_compatible, find_device_addr, mailbox};
 use kernel::*;
 
 #[no_mangle]
-extern "Rust" fn kernel_main(tree: device_tree::DeviceTree) {
+extern "Rust" fn kernel_main(tree: device_tree::DeviceTree<'static>) {
     println!("| starting kernel_main");
+    crate::event::task::spawn_async(async move {
+        main(tree).await;
+    });
+    crate::event::thread::stop();
+}
 
+async fn main(tree: device_tree::DeviceTree<'static>) {
     let mailbox = discover_compatible(&tree, b"brcm,bcm2835-mbox")
         .unwrap()
         .next()
@@ -23,10 +29,10 @@ extern "Rust" fn kernel_main(tree: device_tree::DeviceTree) {
     let mut surface = unsafe { mailbox.get_framebuffer() };
 
     println!("| starting vsync demo; make sure to run with 'just run-ui'");
-    vsync_tearing_demo(&mut surface);
+    vsync_tearing_demo(&mut surface).await;
 }
 
-fn vsync_tearing_demo(surface: &mut mailbox::Surface) {
+async fn vsync_tearing_demo(surface: &mut mailbox::Surface) {
     let (width, height) = surface.dimensions();
 
     for i in 0.. {
@@ -43,6 +49,6 @@ fn vsync_tearing_demo(surface: &mut mailbox::Surface) {
         }
 
         surface.present();
-        surface.wait_for_frame();
+        surface.wait_for_frame().await;
     }
 }

--- a/crates/kernel/src/device/mailbox.rs
+++ b/crates/kernel/src/device/mailbox.rs
@@ -451,10 +451,10 @@ impl Surface {
         // Force writes to go through
         core::hint::black_box(&mut *self.buffer);
     }
-    pub fn wait_for_frame(&self) {
+    pub async fn wait_for_frame(&self) {
         // TODO: proper vsync IRQs?
         let now = crate::sync::get_time();
-        crate::sync::spin_sleep_until(now.next_multiple_of(self.time_step));
+        crate::sync::time::sleep_until(now.next_multiple_of(self.time_step) as u64).await;
     }
 }
 

--- a/crates/kernel/src/device/usb/hcd/dwc/dwc_otg.rs
+++ b/crates/kernel/src/device/usb/hcd/dwc/dwc_otg.rs
@@ -31,7 +31,7 @@ use crate::shutdown;
 use crate::SpinLock;
 use core::ptr;
 
-pub const ChannelCount: usize = 16;
+pub const ChannelCount: usize = 8;
 pub static mut dwc_otg_driver: DWC_OTG = DWC_OTG { base_addr: 0 };
 pub static DWC_CHANNEL_ACTIVE: SpinLock<DwcChannelActive> = SpinLock::new(DwcChannelActive::new());
 pub static DWC_LOCK: SpinLock<DwcLock> = SpinLock::new(DwcLock::new());

--- a/crates/kernel/src/event/context.rs
+++ b/crates/kernel/src/event/context.rs
@@ -336,7 +336,7 @@ fn context_switch_inner(thread: Option<Box<Thread>>, action: SwitchAction<'_>) -
         match action {
             SwitchAction::Yield => {
                 // Re-schedule the thread
-                SCHEDULER.add_task(Event::ScheduleThread(thread))
+                SCHEDULER.add_task(Event::schedule_thread(thread))
             }
             SwitchAction::FreeThread => {
                 // Free the thread
@@ -346,7 +346,7 @@ fn context_switch_inner(thread: Option<Box<Thread>>, action: SwitchAction<'_>) -
                 // Add the thread to a queue, then unlock the lock.
 
                 let mut queue_inner = queue.0.lock();
-                queue_inner.push_back(Event::ScheduleThread(thread));
+                queue_inner.push_back(Event::schedule_thread(thread));
                 lock.unlock();
 
                 // TODO: unlocking this is risky, as it could be owned

--- a/crates/kernel/src/sync/condvar.rs
+++ b/crates/kernel/src/sync/condvar.rs
@@ -1,6 +1,7 @@
 use core::future::Future;
 
 use crate::event::context::{context_switch, SwitchAction};
+use crate::event::task::event_for_waker;
 use crate::event::{scheduler::Queue, Event, SCHEDULER};
 
 use super::lock::SpinLockGuard;
@@ -153,8 +154,8 @@ impl<T> Future for WaitFuture<'_, '_, T> {
             Some(guard) => {
                 // TODO: this is a hack that only works on our executor,
                 // and will break other async libraries
-                let task = crate::event::task::task_id_from_waker(ctx.waker()).unwrap();
-                self.this.queue.add(Event::AsyncTask(task));
+                let task = event_for_waker(ctx.waker()).unwrap();
+                self.this.queue.add(task);
                 drop(guard);
                 core::task::Poll::Pending
             }

--- a/crates/kernel/src/sync/time.rs
+++ b/crates/kernel/src/sync/time.rs
@@ -1,4 +1,14 @@
+use core::future::Future;
+use core::sync::atomic::{AtomicU64, Ordering};
+use core::task::Poll;
+
+use alloc::boxed::Box;
+use alloc::collections::binary_heap::BinaryHeap;
+use alloc::vec::Vec;
+
 use crate::arch::{get_freq_ticks, get_time_ticks, yield_};
+
+use super::SpinLock;
 
 fn convert_time_to_ticks(μs: usize) -> usize {
     (get_freq_ticks() / 250_000) * μs / 4
@@ -22,5 +32,301 @@ pub fn spin_sleep_until(target: usize) {
     while get_time_ticks() < target {
         // TODO: yield vs wfe/wfi?
         unsafe { yield_() };
+    }
+}
+
+pub async fn sleep(μs: u64) {
+    TIMER_SCHEDULER.sleep(μs).await;
+}
+
+pub async fn sleep_until(target: u64) {
+    TIMER_SCHEDULER.sleep_until(target).await;
+}
+
+pub fn interval(μs: u64) -> Interval {
+    TIMER_SCHEDULER.interval(μs)
+}
+
+pub trait TimerBackend {
+    fn get_time(&self) -> u64;
+}
+
+pub struct SystemTimerInterface;
+
+impl TimerBackend for SystemTimerInterface {
+    fn get_time(&self) -> u64 {
+        crate::device::system_timer::get_time()
+    }
+}
+
+struct TimerEvent {
+    _target: u64,
+    waker: core::task::Waker,
+}
+
+#[derive(Copy, Clone, Debug)]
+struct EventIndex(usize);
+
+#[derive(Debug)]
+struct TimerQueueItem {
+    time: u64,
+    index: EventIndex,
+}
+impl PartialOrd for TimerQueueItem {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for TimerQueueItem {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.time.cmp(&other.time).reverse()
+    }
+}
+impl PartialEq for TimerQueueItem {
+    fn eq(&self, other: &Self) -> bool {
+        self.time == other.time
+    }
+}
+impl Eq for TimerQueueItem {}
+
+pub struct TimerScheduler {
+    backend: Box<dyn TimerBackend + Send + Sync>,
+    tasks: SpinLock<Vec<Option<TimerEvent>>>,
+    events: SpinLock<BinaryHeap<TimerQueueItem>>,
+    min_time: AtomicU64,
+}
+
+const fn system_timer_box() -> Box<SystemTimerInterface> {
+    assert!(size_of::<SystemTimerInterface>() == 0);
+    unsafe {
+        core::mem::transmute::<*mut SystemTimerInterface, Box<SystemTimerInterface>>(
+            core::ptr::dangling_mut(),
+        )
+    }
+}
+
+pub static TIMER_SCHEDULER: TimerScheduler = TimerScheduler::new(system_timer_box());
+
+impl TimerScheduler {
+    pub const fn new(backend: Box<dyn TimerBackend + Send + Sync>) -> Self {
+        Self {
+            backend,
+            tasks: SpinLock::new(Vec::new()),
+            events: SpinLock::new(BinaryHeap::new()),
+            min_time: AtomicU64::new(u64::MAX),
+        }
+    }
+
+    pub fn is_ready(&self) -> bool {
+        let cur_time = self.backend.get_time();
+        self.min_time.load(Ordering::Acquire) <= cur_time
+    }
+
+    pub fn run(&self) {
+        let mut tasks = self.tasks.lock();
+        let mut events = self.events.lock();
+        // TODO: ensure that time is monotonically increasing, and consistent
+        // across cores.  (So that other cores don't see an older time than
+        // this when waking and go back to sleep forever.)
+        let now = self.backend.get_time();
+        while let Some(ev) = events.peek() {
+            if ev.time > now {
+                break;
+            }
+            let event = ev.index;
+            events.pop();
+            if let Some(task) = tasks.get_mut(event.0).and_then(|o| o.take()) {
+                task.waker.wake();
+            }
+        }
+        let next_time = events.peek().map(|ev| ev.time).unwrap_or(u64::MAX);
+        self.min_time.store(next_time, Ordering::Release);
+    }
+
+    fn register(&self, target: u64, waker: core::task::Waker) -> EventIndex {
+        // TODO: proper slab allocator
+        let mut guard = self.tasks.lock();
+        guard.push(Some(TimerEvent {
+            _target: target,
+            waker,
+        }));
+        let idx = EventIndex(guard.len() - 1);
+        drop(guard);
+        self.events.lock().push(TimerQueueItem {
+            time: target,
+            index: idx,
+        });
+        self.min_time.fetch_min(target, Ordering::Release);
+        idx
+    }
+
+    fn unregister(&self, idx: EventIndex) {
+        // TODO: proper slab allocator
+        let mut guard = self.tasks.lock();
+        guard[idx.0] = None;
+        // TODO: remove from heap?
+    }
+
+    fn timer_future(
+        &'static self,
+        target: Option<u64>,
+        period: Option<u64>,
+        missed: MissedTicks,
+    ) -> TimerFuture {
+        TimerFuture {
+            scheduler: self,
+            target,
+            missed,
+            period: period.unwrap_or(u64::MAX),
+            state: TimerFutureState::Unregistered,
+        }
+    }
+
+    pub fn sleep(&'static self, duration: u64) -> TimerFuture {
+        let cur_time = self.backend.get_time();
+        let target = cur_time + duration;
+        self.timer_future(Some(target), None, MissedTicks::Burst)
+    }
+    pub fn sleep_until(&'static self, target: u64) -> TimerFuture {
+        self.timer_future(Some(target), None, MissedTicks::Burst)
+    }
+    pub fn interval(&'static self, interval: u64) -> Interval {
+        let cur_time = self.backend.get_time();
+        Interval(self.timer_future(Some(cur_time), Some(interval), MissedTicks::Burst))
+    }
+}
+
+pub enum MissedTicks {
+    Burst,
+    Skip,
+    Delay,
+}
+
+pub struct TimerFuture {
+    scheduler: &'static TimerScheduler,
+    target: Option<u64>,
+    period: u64,
+    missed: MissedTicks,
+    state: TimerFutureState,
+}
+
+#[derive(Debug)]
+enum TimerFutureState {
+    Unregistered,
+    Registered {
+        idx: EventIndex,
+        waker: core::task::Waker,
+    },
+}
+
+impl TimerFuture {
+    fn next_target(&self, target: u64, now: u64) -> Option<u64> {
+        let next_target = target.checked_add(self.period)?;
+
+        if let Some(late) = now.checked_sub(next_target) {
+            // next_target <= now, so we missed a tick
+            match self.missed {
+                MissedTicks::Burst => Some(next_target),
+                MissedTicks::Skip => {
+                    let diff = late.checked_next_multiple_of(self.period)?;
+                    next_target.checked_add(diff)
+                }
+                MissedTicks::Delay => now.checked_add(self.period),
+            }
+        } else {
+            Some(next_target)
+        }
+    }
+
+    fn poll_next(&mut self, cx: &mut core::task::Context<'_>) -> Poll<()> {
+        let Some(target) = self.target else {
+            return Poll::Pending;
+        };
+
+        let now = self.scheduler.backend.get_time();
+        if now >= target {
+            if let TimerFutureState::Registered { idx, .. } = self.state {
+                self.scheduler.unregister(idx);
+            }
+            self.target = self.next_target(target, now);
+
+            if let Some(next_target) = self.target {
+                if next_target >= now {
+                    let new_waker = cx.waker();
+                    let new_idx = self.scheduler.register(next_target, new_waker.clone());
+                    if let TimerFutureState::Registered { idx, waker } = &mut self.state {
+                        *idx = new_idx;
+                        waker.clone_from(&*new_waker);
+                    } else {
+                        self.state = TimerFutureState::Registered {
+                            idx: new_idx,
+                            waker: new_waker.clone(),
+                        };
+                    }
+                } else {
+                    self.state = TimerFutureState::Unregistered;
+                }
+            } else {
+                self.state = TimerFutureState::Unregistered;
+            }
+
+            return Poll::Ready(());
+        }
+
+        match self.state {
+            TimerFutureState::Unregistered => {
+                let waker = cx.waker();
+                let idx = self.scheduler.register(target, waker.clone());
+                self.state = TimerFutureState::Registered {
+                    idx,
+                    waker: waker.clone(),
+                };
+            }
+            TimerFutureState::Registered {
+                ref mut idx,
+                ref mut waker,
+            } => {
+                if !cx.waker().will_wake(waker) {
+                    let new_waker = cx.waker();
+                    self.scheduler.unregister(*idx);
+                    *idx = self.scheduler.register(target, new_waker.clone());
+                    *waker = new_waker.clone();
+                }
+            }
+        }
+        Poll::Pending
+    }
+}
+
+impl Future for TimerFuture {
+    type Output = ();
+    fn poll(
+        self: core::pin::Pin<&mut Self>,
+        cx: &mut core::task::Context<'_>,
+    ) -> Poll<Self::Output> {
+        self.get_mut().poll_next(cx)
+    }
+}
+
+impl Drop for TimerFuture {
+    fn drop(&mut self) {
+        if let TimerFutureState::Registered { idx, .. } = self.state {
+            self.scheduler.unregister(idx);
+        }
+    }
+}
+
+pub struct Interval(TimerFuture);
+
+impl Interval {
+    pub fn set_missed_tick_behavior(&mut self, missed: MissedTicks) {
+        self.0.missed = missed;
+    }
+    pub fn with_missed_tick_behavior(mut self, missed: MissedTicks) -> Self {
+        self.0.missed = missed;
+        self
+    }
+    pub fn tick(&mut self) -> impl Future<Output = bool> + '_ {
+        core::future::poll_fn(|cx| self.0.poll_next(cx).map(|_| true))
     }
 }

--- a/crates/kernel/src/syscall/proc.rs
+++ b/crates/kernel/src/syscall/proc.rs
@@ -68,7 +68,7 @@ pub unsafe fn sys_spawn(ctx: &mut Context) -> *mut Context {
     );
     let mut user_thread = unsafe { thread::Thread::new_user(process, user_sp, user_entry) };
     user_thread.context.as_mut().unwrap().regs[0] = user_x0;
-    event::SCHEDULER.add_task(event::Event::ScheduleThread(user_thread));
+    event::SCHEDULER.add_task(event::Event::schedule_thread(user_thread));
 
     ctx.regs[0] = wait_fd;
     ctx


### PR DESCRIPTION
Not the cleanest interface at the moment, but it works.  It's not currently integrated with the timer backends, but in the future it could use them to communicate intended wake-up times and allow the scheduler to sleep more efficiently (and manage higher precision times).

This will also need a way to have schedule events with high (or close to real-time) priority for USB events.