### PR TITLE
Real Time scheduling of USB Interrupts

### DIFF
--- a/crates/kernel/src/device/usb/usbd/endpoint.rs
+++ b/crates/kernel/src/device/usb/usbd/endpoint.rs
@@ -22,14 +22,6 @@ use crate::event::schedule_rt;
 use crate::shutdown;
 use alloc::boxed::Box;
 
-pub fn schedule_finish_bulk_endpoint_callback_in(endpoint: endpoint_descriptor, hcint: u32) {
-    schedule_rt(move || finish_bulk_endpoint_callback_in(endpoint, hcint));
-}
-
-pub fn schedule_finish_bulk_endpoint_callback_out(endpoint: endpoint_descriptor, hcint: u32) {
-    schedule_rt(move || finish_bulk_endpoint_callback_out(endpoint, hcint));
-}
-
 pub fn finish_bulk_endpoint_callback_in(endpoint: endpoint_descriptor, hcint: u32) {
     let device = unsafe { &mut *endpoint.device };
 
@@ -96,10 +88,6 @@ pub fn finish_bulk_endpoint_callback_out(endpoint: endpoint_descriptor, hcint: u
     }
 
     //Good to go
-}
-
-pub fn schedule_finish_interrupt_endpoint_callback(endpoint: endpoint_descriptor, hcint: u32) {
-    schedule_rt(move || finish_interrupt_endpoint_callback(endpoint, hcint));
 }
 
 pub fn finish_interrupt_endpoint_callback(endpoint: endpoint_descriptor, hcint: u32) {
@@ -184,7 +172,7 @@ pub fn interrupt_endpoint_callback(endpoint: endpoint_descriptor) {
             8,
             PacketId::Data0,
             endpoint.timeout,
-            schedule_finish_interrupt_endpoint_callback,
+            finish_interrupt_endpoint_callback,
             endpoint,
         )
     };

--- a/crates/kernel/src/device/usb/usbd/usbd.rs
+++ b/crates/kernel/src/device/usb/usbd/usbd.rs
@@ -103,10 +103,10 @@ pub unsafe fn UsbBulkMessage(
 
         if pipe.direction == UsbDirection::Out {
             DWC_CHANNEL_CALLBACK.callback[available_channel as usize] =
-                Some(finish_bulk_endpoint_callback_out);
+                Some(schedule_finish_bulk_endpoint_callback_out);
         } else {
             DWC_CHANNEL_CALLBACK.callback[available_channel as usize] =
-                Some(finish_bulk_endpoint_callback_in);
+                Some(schedule_finish_bulk_endpoint_callback_in);
         }
     }
 

--- a/crates/kernel/src/device/usb/usbd/usbd.rs
+++ b/crates/kernel/src/device/usb/usbd/usbd.rs
@@ -103,10 +103,10 @@ pub unsafe fn UsbBulkMessage(
 
         if pipe.direction == UsbDirection::Out {
             DWC_CHANNEL_CALLBACK.callback[available_channel as usize] =
-                Some(schedule_finish_bulk_endpoint_callback_out);
+                Some(finish_bulk_endpoint_callback_out);
         } else {
             DWC_CHANNEL_CALLBACK.callback[available_channel as usize] =
-                Some(schedule_finish_bulk_endpoint_callback_in);
+                Some(finish_bulk_endpoint_callback_in);
         }
     }
 

--- a/crates/kernel/src/event/mod.rs
+++ b/crates/kernel/src/event/mod.rs
@@ -26,6 +26,14 @@ where
     SCHEDULER.add_task(ev);
 }
 
+pub fn schedule_rt<F>(f: F)
+where
+    F: FnOnce() + Send + 'static,
+{
+    let ev = Event::Function(Box::new(f));
+    SCHEDULER.add_rt_task(ev);
+}
+
 pub unsafe extern "C" fn run_event_loop() -> ! {
     loop {
         let ev = SCHEDULER.wait_for_task();


### PR DESCRIPTION
Adding a priority scheduler in the currently implemented scheduler. Then, the USB interrupt context would schedule tasks with locks in the priority scheduler instead of handling them in the interrupt context.

This should not have much of an impact on the timing of the USB code. 

The only lock that isn't able to be removed is the `DWC_LOCK` spinlock. However, this shouldn't be too bad as the lock is only used in the interrupt and is guarding a very short region.
