### PR TITLE
Always save SP_EL0 in Context

### DIFF
--- a/crates/kernel/examples/user.rs
+++ b/crates/kernel/examples/user.rs
@@ -81,7 +81,6 @@ extern "Rust" fn kernel_main(_device_tree: device_tree::DeviceTree) {
     context::CORES.with_current(|core| {
         let mut thread = core.thread.take().unwrap();
         thread.user_regs = Some(thread::UserRegs {
-            sp_el0: 0,
             ttbr0_el1: ttbr0,
             usermode: false,
         });

--- a/crates/kernel/examples/vaToPaUser.rs
+++ b/crates/kernel/examples/vaToPaUser.rs
@@ -35,7 +35,6 @@ extern "Rust" fn kernel_main(_device_tree: device_tree::DeviceTree) {
     context::CORES.with_current(|core| {
         let mut thread = core.thread.take().unwrap();
         thread.user_regs = Some(thread::UserRegs {
-            sp_el0: 0,
             ttbr0_el1: ttbr0,
             usermode: false,
         });

--- a/crates/kernel/src/event/mod.rs
+++ b/crates/kernel/src/event/mod.rs
@@ -92,7 +92,6 @@ pub unsafe fn timer_handler(ctx: &mut Context) -> *mut Context {
     if ctx.current_el() == context::ExceptionLevel::EL1 {
         let stacks = &raw const crate::arch::boot::STACKS;
         let ptr_range = stacks as usize..stacks.wrapping_add(1) as usize;
-        #[allow(deprecated)]
         let kernel_sp = ctx.kernel_sp;
         assert!(
             !ptr_range.contains(&kernel_sp),

--- a/crates/kernel/src/syscall/exec.rs
+++ b/crates/kernel/src/syscall/exec.rs
@@ -119,7 +119,7 @@ pub unsafe fn sys_execve_fd(ctx: &mut Context) -> *mut Context {
         {
             let mut regs = context.regs();
             regs.regs = [0; 31];
-            regs.link_reg = user_entry as usize;
+            regs.elr = user_entry as usize;
             regs.spsr = 0b0000; // TODO: standardize initial SPSR values
         }
         context.set_sp(user_sp);


### PR DESCRIPTION
This cleans up the handling of stack pointers in the context and removes the `#[deprecated]` hack I introduced in #47.