### PR TITLE
Deadlock protections and race condition fixes

### DIFF
--- a/crates/kernel/src/arch/aarch64/interrupts.rs
+++ b/crates/kernel/src/arch/aarch64/interrupts.rs
@@ -1,4 +1,4 @@
-pub struct InterruptsState(u64);
+pub struct InterruptsState(pub(crate) u64);
 
 impl core::fmt::Debug for InterruptsState {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {

--- a/crates/kernel/src/device.rs
+++ b/crates/kernel/src/device.rs
@@ -110,7 +110,7 @@ pub fn init_devices(tree: &DeviceTree<'_>) {
         let (uart_addr, _) = find_device_addr(uart).unwrap().unwrap();
         let uart_base = unsafe { map_device(uart_addr) }.as_ptr();
 
-        unsafe { uart::UART.init(SpinLock::new(uart::UARTInner::new(uart_base))) };
+        unsafe { uart::UART.init(uart::UARTLock::new(uart::UARTInner::new(uart_base))) };
         println!("| initialized UART");
     }
 

--- a/crates/kernel/src/device/usb/hcd/dwc/dwc_otg.rs
+++ b/crates/kernel/src/device/usb/hcd/dwc/dwc_otg.rs
@@ -28,13 +28,14 @@ use crate::device::MAILBOX;
 use crate::event::context::Context;
 use crate::event::schedule_rt;
 use crate::shutdown;
-use crate::SpinLock;
+use crate::sync::InterruptSpinLock;
+use crate::sync::SpinLock;
 use core::ptr;
 
 pub const ChannelCount: usize = 8;
 pub static mut dwc_otg_driver: DWC_OTG = DWC_OTG { base_addr: 0 };
 pub static DWC_CHANNEL_ACTIVE: SpinLock<DwcChannelActive> = SpinLock::new(DwcChannelActive::new());
-pub static DWC_LOCK: SpinLock<DwcLock> = SpinLock::new(DwcLock::new());
+pub static DWC_LOCK: InterruptSpinLock<DwcLock> = InterruptSpinLock::new(DwcLock::new());
 pub static mut DWC_CHANNEL_CALLBACK: DwcChannelCallback = DwcChannelCallback::new();
 
 pub fn dwc_otg_register_interrupt_handler() {

--- a/crates/kernel/src/event/async_handler.rs
+++ b/crates/kernel/src/event/async_handler.rs
@@ -215,6 +215,11 @@ impl<'outer> HandlerContext<'outer> {
         ResumedContext(())
     }
 
+    pub fn resume_return(mut self, x0: usize) -> ResumedContext {
+        self.regs().regs[0] = x0;
+        ResumedContext(())
+    }
+
     pub fn regs(&mut self) -> ThreadRefMut<'_, Context> {
         let thread = self.cur_thread_mut().as_mut().unwrap();
         ThreadRefMut {

--- a/crates/kernel/src/event/task.rs
+++ b/crates/kernel/src/event/task.rs
@@ -7,7 +7,7 @@ use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 
 use super::scheduler::Priority;
 use super::{Event, EventKind, SCHEDULER};
-use crate::sync::SpinLock;
+use crate::sync::InterruptSpinLock;
 
 pub fn spawn_async(future: impl Future<Output = ()> + Send + 'static) {
     let priority = Priority::Normal;
@@ -51,14 +51,14 @@ enum TaskState {
 pub struct TaskList {
     // TODO: generational arena
     count: AtomicUsize,
-    tasks: SpinLock<BTreeMap<TaskId, TaskState>>,
+    tasks: InterruptSpinLock<BTreeMap<TaskId, TaskState>>,
 }
 
 impl TaskList {
     pub const fn new() -> Self {
         TaskList {
             count: AtomicUsize::new(0),
-            tasks: SpinLock::new(BTreeMap::new()),
+            tasks: InterruptSpinLock::new(BTreeMap::new()),
         }
     }
 

--- a/crates/kernel/src/process/fd.rs
+++ b/crates/kernel/src/process/fd.rs
@@ -117,7 +117,7 @@ impl FileDescriptor for DummyFd {
     }
 }
 
-pub struct UartFd(pub &'static crate::sync::SpinLock<crate::device::uart::UARTInner>);
+pub struct UartFd(pub &'static crate::device::uart::UARTLock);
 
 // TODO: how to handle non-zero offsets for non-seekable files?
 impl FileDescriptor for UartFd {

--- a/crates/kernel/src/syscall/mod.rs
+++ b/crates/kernel/src/syscall/mod.rs
@@ -1,6 +1,4 @@
 use crate::event::exceptions::register_syscall_handler;
-use crate::process::Process;
-use alloc::sync::Arc;
 
 pub mod channel;
 pub mod exec;
@@ -29,16 +27,4 @@ pub unsafe fn register_syscalls() {
         register_syscall_handler(16, exec::sys_execve_fd);
         register_syscall_handler(17, proc::sys_wait);
     }
-}
-
-fn current_process() -> Option<Arc<Process>> {
-    crate::event::context::CORES.with_current(|core| {
-        let thread = core.thread.take().unwrap();
-        // TODO: don't require cloning here
-        // TODO: how to make longer periods of access to the current thread sound?
-        // (ie. either internal mutability, or can't yield/preempt/check preempt status...)
-        let cur_process = thread.process.clone();
-        core.thread.set(Some(thread));
-        cur_process
-    })
 }


### PR DESCRIPTION
- Make `SpinLock::lock` panic if called from an interrupt handler, as that is almost guaranteed to allow for deadlocks; if you need a lock in an interrupt handler, use `InterruptSpinLock`.
- Fixes a few deadlock sources by using `InterruptSpinLock` instead of `SpinLock`.  This isn't the best solution, but it's the simplest for now.  (In the future, kernel logging should be a lockless queue of some kind, rather than a locked UART)
- Enables interrupts when running syscall handlers
- Adds a `run_event_handler` wrapper for syscall handlers that don't need to yield.
- Fixes a race condition in `restore_context`, where if interrupts were enabled some of the control registers could be overwritten.
- Bypasses the UART lock when printing panic messages.