### PR TITLE
Usb Transfer Queues

### DIFF
--- a/crates/kernel/src/device/usb/device/rndis.rs
+++ b/crates/kernel/src/device/usb/device/rndis.rs
@@ -10,7 +10,7 @@ use crate::device::usb::types::*;
 use crate::device::usb::usbd::device::*;
 use crate::device::usb::usbd::pipe::*;
 use crate::device::usb::usbd::request::*;
-use crate::device::usb::usbd::usbd::UsbBulkMessage;
+use crate::device::usb::usbd::usbd::UsbSendBulkMessage;
 use crate::device::usb::UsbControlMessage;
 
 use crate::device::usb::device::net::*;
@@ -383,7 +383,7 @@ pub unsafe fn rndis_send_packet(
     }
 
     let result = unsafe {
-        UsbBulkMessage(
+        UsbSendBulkMessage(
             device,
             UsbPipeAddress {
                 transfer_type: UsbTransfer::Bulk,
@@ -416,7 +416,7 @@ pub unsafe fn rndis_receive_packet(
     buffer_length: u32,
 ) -> ResultCode {
     let result = unsafe {
-        UsbBulkMessage(
+        UsbSendBulkMessage(
             device,
             UsbPipeAddress {
                 transfer_type: UsbTransfer::Bulk,

--- a/crates/kernel/src/device/usb/usbd.rs
+++ b/crates/kernel/src/device/usb/usbd.rs
@@ -4,3 +4,4 @@ pub mod endpoint;
 pub mod pipe;
 pub mod request;
 pub mod usbd;
+pub mod transfer;

--- a/crates/kernel/src/device/usb/usbd.rs
+++ b/crates/kernel/src/device/usb/usbd.rs
@@ -3,5 +3,5 @@ pub mod device;
 pub mod endpoint;
 pub mod pipe;
 pub mod request;
-pub mod usbd;
 pub mod transfer;
+pub mod usbd;

--- a/crates/kernel/src/device/usb/usbd/endpoint.rs
+++ b/crates/kernel/src/device/usb/usbd/endpoint.rs
@@ -8,6 +8,7 @@
  */
 use crate::device::usb;
 
+use crate::device::usb::UsbSendInterruptMessage;
 use usb::dwc_hub;
 use usb::hcd::dwc::dwc_otg::HcdUpdateTransferSize;
 use usb::hcd::dwc::dwc_otgreg::{HCINT_CHHLTD, HCINT_NAK, HCINT_XFERCOMPL};
@@ -15,7 +16,6 @@ use usb::types::*;
 use usb::usbd::device::*;
 use usb::usbd::pipe::*;
 use usb::PacketId;
-use crate::device::usb::UsbSendInterruptMessage;
 
 use crate::event::task::spawn_async_rt;
 use crate::shutdown;
@@ -73,18 +73,12 @@ pub fn finish_bulk_endpoint_callback_out(endpoint: endpoint_descriptor, hcint: u
     device.last_transfer = endpoint.buffer_length - transfer_size;
 
     if hcint & HCINT_CHHLTD == 0 {
-        println!(
-            "| Endpoint {}: HCINT_CHHLTD not set, aborting.",
-            channel
-        );
+        println!("| Endpoint {}: HCINT_CHHLTD not set, aborting.", channel);
         shutdown();
     }
 
     if hcint & HCINT_XFERCOMPL == 0 {
-        println!(
-            "| Endpoint {}: HCINT_XFERCOMPL not set, aborting.",
-            channel
-        );
+        println!("| Endpoint {}: HCINT_XFERCOMPL not set, aborting.", channel);
         shutdown();
     }
 
@@ -127,10 +121,7 @@ pub fn finish_interrupt_endpoint_callback(endpoint: endpoint_descriptor, hcint: 
             );
         }
     } else {
-        println!(
-            "| Endpoint {}: Unknown interrupt, aborting.",
-            channel
-        );
+        println!("| Endpoint {}: Unknown interrupt, aborting.", channel);
         shutdown();
     }
 

--- a/crates/kernel/src/device/usb/usbd/transfer.rs
+++ b/crates/kernel/src/device/usb/usbd/transfer.rs
@@ -1,0 +1,76 @@
+/**
+ *
+ * usbd/transfer.rs
+ *  By Aaron Lo
+ *   
+ *   This file contains implemenation for USB transfers
+ *
+ */
+
+use crate::device::usb::usbd::pipe::UsbPipeAddress;
+use alloc::boxed::Box;
+use crate::device::usb::hcd::dwc::dwc_otg::PacketId;
+use crate::device::usb::types::UsbTransfer;
+use crate::ringbuffer::SpscRingBuffer;
+use crate::sync::InterruptSpinLock;
+
+use super::endpoint::*;
+pub const RING_BUFFER_SIZE: usize = 4096;
+pub struct UsbTransferQueue {
+    pub interrupt_queue: InterruptSpinLock<SpscRingBuffer<RING_BUFFER_SIZE, Box<UsbXfer>>>,
+    pub bulk_queue: InterruptSpinLock<SpscRingBuffer<RING_BUFFER_SIZE, Box<UsbXfer>>>,
+}
+
+unsafe impl Sync for UsbTransferQueue {}
+
+impl UsbTransferQueue {
+    pub const fn new() -> Self {
+        UsbTransferQueue {
+            interrupt_queue: InterruptSpinLock::new(SpscRingBuffer::new()),
+            bulk_queue: InterruptSpinLock::new(SpscRingBuffer::new()),
+        }
+    }
+
+    pub fn add_transfer(&self, transfer: Box<UsbXfer>, transfer_type: UsbTransfer) -> Result<(), Box<UsbXfer>> {
+        let transfer_result;
+        match transfer_type {
+            UsbTransfer::Interrupt => {
+                unsafe {
+                    transfer_result = self.interrupt_queue.lock().try_send(transfer);
+                }
+            }
+            UsbTransfer::Bulk => {
+                unsafe {
+                    transfer_result = self.bulk_queue.lock().try_send(transfer);
+                }
+            }
+            _ =>{
+                panic!("Unsupported transfer type");
+            }
+        }
+
+        transfer_result
+    }
+
+    pub fn get_transfer(&self) -> Option<Box<UsbXfer>> {
+        let mut transfer_result;
+        unsafe {
+            transfer_result = self.interrupt_queue.lock().try_recv();
+        }
+        if transfer_result.is_none() {
+            unsafe {
+                transfer_result = self.bulk_queue.lock().try_recv();
+            }
+        }
+        transfer_result
+    }
+}
+
+pub struct UsbXfer {
+    pub endpoint_descriptor: endpoint_descriptor,
+    pub buffer: *mut u8,
+    pub buffer_length: u32,
+    pub callback: Option<fn(endpoint_descriptor, u32, u8)>,
+    pub packet_id: PacketId,
+    pub pipe: UsbPipeAddress,
+}

--- a/crates/kernel/src/device/usb/usbd/transfer.rs
+++ b/crates/kernel/src/device/usb/usbd/transfer.rs
@@ -1,3 +1,5 @@
+use crate::device::usb::hcd::dwc::dwc_otg::PacketId;
+use crate::device::usb::types::UsbTransfer;
 /**
  *
  * usbd/transfer.rs
@@ -6,13 +8,10 @@
  *   This file contains implemenation for USB transfers
  *
  */
-
 use crate::device::usb::usbd::pipe::UsbPipeAddress;
-use alloc::boxed::Box;
-use crate::device::usb::hcd::dwc::dwc_otg::PacketId;
-use crate::device::usb::types::UsbTransfer;
 use crate::ringbuffer::SpscRingBuffer;
 use crate::sync::InterruptSpinLock;
+use alloc::boxed::Box;
 
 use super::endpoint::*;
 pub const RING_BUFFER_SIZE: usize = 4096;
@@ -31,20 +30,20 @@ impl UsbTransferQueue {
         }
     }
 
-    pub fn add_transfer(&self, transfer: Box<UsbXfer>, transfer_type: UsbTransfer) -> Result<(), Box<UsbXfer>> {
+    pub fn add_transfer(
+        &self,
+        transfer: Box<UsbXfer>,
+        transfer_type: UsbTransfer,
+    ) -> Result<(), Box<UsbXfer>> {
         let transfer_result;
         match transfer_type {
-            UsbTransfer::Interrupt => {
-                unsafe {
-                    transfer_result = self.interrupt_queue.lock().try_send(transfer);
-                }
-            }
-            UsbTransfer::Bulk => {
-                unsafe {
-                    transfer_result = self.bulk_queue.lock().try_send(transfer);
-                }
-            }
-            _ =>{
+            UsbTransfer::Interrupt => unsafe {
+                transfer_result = self.interrupt_queue.lock().try_send(transfer);
+            },
+            UsbTransfer::Bulk => unsafe {
+                transfer_result = self.bulk_queue.lock().try_send(transfer);
+            },
+            _ => {
                 panic!("Unsupported transfer type");
             }
         }

--- a/crates/kernel/src/device/usb/usbd/usbd.rs
+++ b/crates/kernel/src/device/usb/usbd/usbd.rs
@@ -83,7 +83,6 @@ pub unsafe fn UsbSendBulkMessage(
     device_endpoint_number: u8,
     timeout_: u32,
 ) -> ResultCode {
-
     let callback_fn = if pipe.direction == UsbDirection::In {
         finish_bulk_endpoint_callback_in
     } else {
@@ -131,11 +130,7 @@ pub unsafe fn UsbSendBulkMessage(
             return ResultCode::OK;
         }
 
-        return UsbBulkMessage(
-            device,
-            transfer.unwrap(),
-            available_channel,
-        );
+        return UsbBulkMessage(device, transfer.unwrap(), available_channel);
     }
 }
 
@@ -145,7 +140,8 @@ pub unsafe fn UsbBulkMessage(
     channel: u8,
 ) -> ResultCode {
     unsafe {
-        DWC_CHANNEL_CALLBACK.endpoint_descriptors[channel as usize] = Some(usb_xfer.endpoint_descriptor);
+        DWC_CHANNEL_CALLBACK.endpoint_descriptors[channel as usize] =
+            Some(usb_xfer.endpoint_descriptor);
         DWC_CHANNEL_CALLBACK.callback[channel as usize] = usb_xfer.callback;
     }
 
@@ -178,7 +174,6 @@ pub unsafe fn UsbSendInterruptMessage(
     callback: fn(endpoint_descriptor, u32, u8),
     endpoint: endpoint_descriptor,
 ) -> ResultCode {
-
     let b = Box::new(UsbXfer {
         endpoint_descriptor: endpoint,
         buffer: buffer,
@@ -208,23 +203,19 @@ pub unsafe fn UsbSendInterruptMessage(
             return ResultCode::OK;
         }
 
-        return UsbInterruptMessage(
-            device,
-            transfer.unwrap(),
-            available_channel
-        );
+        return UsbInterruptMessage(device, transfer.unwrap(), available_channel);
     }
 }
 
 pub unsafe fn UsbInterruptMessage(
     device: &mut UsbDevice,
     usb_xfer: Box<UsbXfer>,
-    channel: u8
+    channel: u8,
 ) -> ResultCode {
-
     unsafe {
         DWC_CHANNEL_CALLBACK.callback[channel as usize] = Some(usb_xfer.callback.unwrap());
-        DWC_CHANNEL_CALLBACK.endpoint_descriptors[channel as usize] = Some(usb_xfer.endpoint_descriptor);
+        DWC_CHANNEL_CALLBACK.endpoint_descriptors[channel as usize] =
+            Some(usb_xfer.endpoint_descriptor);
     }
 
     let result = unsafe {


### PR DESCRIPTION
Updating the channel reservation system to go through a queuing system. This way, if all channels are occupied, it doesn't lead to a lock-down of the USB system. 

Requires more stress testing in the future (ideally, it can be done through networking).