### PR TITLE
Mini UART initialization and clocking

### DIFF
--- a/crates/kernel/.gitignore
+++ b/crates/kernel/.gitignore
@@ -1,1 +1,2 @@
 *.pcap
+log

--- a/crates/kernel/examples/user.rs
+++ b/crates/kernel/examples/user.rs
@@ -85,7 +85,7 @@ async fn main() {
 
     {
         let mut fds = process.file_descriptors.lock();
-        let uart_fd = Arc::new(process::fd::UartFd(device::uart::UART.get())) as Arc<_>;
+        let uart_fd = Arc::new(process::fd::UartFd(device::bcm2835_aux::MINI_UART.get())) as Arc<_>;
         let _ = fds.set(0, Arc::clone(&uart_fd));
         let _ = fds.set(1, Arc::clone(&uart_fd));
         let _ = fds.set(2, uart_fd);

--- a/crates/kernel/scripts/attach-serial.sh
+++ b/crates/kernel/scripts/attach-serial.sh
@@ -1,0 +1,5 @@
+SERIAL_DEV=/dev/serial/by-id/usb-FTDI_FT232R_USB_UART_B0044ASI-if00-port0
+LOGFILE=log/$(date -Is).log
+echo "Logging to $LOGFILE"
+tio "$SERIAL_DEV" -b 115200 -d 8 -s 1 -p none -f none -m INLCRNL -L --log-file="$LOGFILE"
+echo "Log saved to $LOGFILE"

--- a/crates/kernel/scripts/run.sh
+++ b/crates/kernel/scripts/run.sh
@@ -35,19 +35,19 @@ if test "$DEBUG_ARGS" = "-s -S" ; then
 fi
 
 # TODO: qemu's pipe handling drops characters, doesn't flush
-UART_PIPE="uart2"
-if test ! -p "$UART_PIPE" ; then
-    mkfifo "$UART_PIPE"
-fi
-SERIAL_ALT="pipe:$UART_PIPE"
+#UART_PIPE="uart2"
+#if test ! -p "$UART_PIPE" ; then
+#    mkfifo "$UART_PIPE"
+#fi
+#SERIAL_ALT="pipe:$UART_PIPE"
 # SERIAL_ALT="tcp:127.0.0.1:5377" # listen with nc -kl 5377
 
 qemu-system-aarch64 \
     ${QEMU_TARGET_HARDWARE} \
     -kernel kernel.bin \
     -drive file=sdcard.img,if=sd,format=raw \
+    -serial null \
     -serial stdio \
-    -serial "${SERIAL_ALT}" \
     -display "${QEMU_DISPLAY}" \
     "${QEMU_DEBUG_PFX}" "${QEMU_DEBUG}" \
     ${QEMU_DEVICES} \

--- a/crates/kernel/src/device/bcm2835_aux.rs
+++ b/crates/kernel/src/device/bcm2835_aux.rs
@@ -1,6 +1,17 @@
-use crate::sync::{SpinLock, Volatile};
+use crate::sync::{InterruptSpinLock, UnsafeInit, Volatile};
+
+use super::gpio::{GpioFunction, GpioPull};
+use super::GPIO;
 
 // https://www.raspberrypi.org/app/uploads/2012/02/BCM2835-ARM-Peripherals.pdf
+
+// TODO: This shouldn't actually use an interrupt-disabling lock, but we
+// don't currently have a better logging system.  (Interrupt handlers
+// should not print, and can still deadlock with this, but it should
+// make those deadlocks rare.)
+pub type MiniUartLock = InterruptSpinLock<MiniUart>;
+
+pub static MINI_UART: UnsafeInit<MiniUartLock> = unsafe { UnsafeInit::uninit() };
 
 pub struct MiniUart {
     base: *mut (),
@@ -34,6 +45,72 @@ impl MiniUart {
     const AUX_SPI1_PEEK_REG: usize = 0x00D4;  // SPI 2 Peek 16
 }
 
+bitflags::bitflags! {
+    struct IirReg: u32 {
+        // Access to the MS 8 bits of the 16-bit baudrate register.
+        // (Only if DLAB_ACCESS bit is set in LCR)
+        const BAUD_MSBYTE = 0xFF;
+
+        const RECV_INT_ENABLE = 1 << 1;
+        const TRANS_INT_ENABLE = 1 << 0;
+    }
+
+    struct IerReg: u32 {
+        const FIFO_ENABLES = 0b11 << 6;
+        const INT_ID_MASK = 0b11 << 1;
+        const CLR_RECV_FIFO = 1 << 2;
+        const CLR_TRANS_FIFO = 1 << 1;
+        const INT_PENDING = 1 << 0;
+    }
+
+    struct LcrReg: u32 {
+        const DLAB_ACCESS = 1 << 7;
+        const BREAK = 1 << 6;
+        // Bit 1 is undocumented, but must be 1 for 8 bit mode.
+        const DATA_8BIT = 0b11 << 0;
+    }
+
+    struct McrReg: u32 {
+        const RTS = 1 << 1;
+    }
+
+    struct LsrReg: u32 {
+        const TRANS_IDLE = 1 << 6;
+        const TRANS_READY = 1 << 5;
+        const RECV_OVER = 1 << 1;
+        const DATA_READY = 1 << 0;
+    }
+
+    struct MsrReg: u32 {
+        const CTS_STATUS = 1 << 5;
+    }
+
+    struct CntrlReg: u32 {
+        const CTS_ASSERT_LOW = 1 << 7;
+        const RTS_ASSERT_LOW = 1 << 6;
+        const RTS_AUTO_MASK = 0b11 << 4;
+        const TRANS_AUTO = 1 << 3;
+        const RECV_AUTO = 1 << 2;
+        const TRANS_ENABLE = 1 << 1;
+        const RECV_ENABLE = 1 << 0;
+    }
+
+    struct StatReg: u32 {
+        const TRANS_LEVEL = 0b1111 << 24;
+        const RECV_LEVEL = 0b1111 << 16;
+        const TRANS_DONE = 1 << 9;
+        const TRANS_EMPTY = 1 << 8;
+        const CTS_STATUS = 1 << 7;
+        const RTS_STATUS = 1 << 6;
+        const TRANS_FULL = 1 << 5;
+        const RECV_OVER = 1 << 4;
+        const TRANS_IDLE = 1 << 3;
+        const RECV_IDEL = 1 << 2;
+        const TRANS_AVAIL = 1 << 1;
+        const RECV_AVAIL = 1 << 1;
+    }
+}
+
 impl MiniUart {
     pub unsafe fn new(base: *mut ()) -> Self {
         // TODO[hardware]: proper mini UART initialization
@@ -42,14 +119,45 @@ impl MiniUart {
         unsafe {
             // Enable mini UART, disable both SPI modules
             this.reg(Self::AUX_ENABLES).write(0b001);
-            // Clear bit 7, DLAB (baudrate register access instead of data)
-            // Clear bit 6, break
-            // Set bit 0, 8-bit mode
-            #[allow(clippy::eq_op)]
-            this.reg(Self::AUX_MU_LCR_REG)
-                .write((0 << 7) | (0 << 6) | (1 << 0));
 
-            // TODO: initialize GPIO
+            this.reg(Self::AUX_MU_IER_REG).write(IerReg::empty().bits());
+            this.reg(Self::AUX_MU_CNTL_REG)
+                .write(CntrlReg::empty().bits());
+            this.reg(Self::AUX_MU_LCR_REG)
+                .write((LcrReg::DATA_8BIT).bits());
+            this.reg(Self::AUX_MU_MCR_REG).write(McrReg::empty().bits());
+            this.reg(Self::AUX_MU_IER_REG).write(IerReg::empty().bits()); // ????
+            this.reg(Self::AUX_MU_IIR_REG).write(0xC6); // ???
+
+            let clock_rate;
+            {
+                let mut mailbox = super::MAILBOX.get().lock();
+                clock_rate = mailbox
+                    .get_property(super::mailbox::PropGetClockRate {
+                        id: super::mailbox::CLOCK_CORE,
+                    })
+                    .unwrap()
+                    .rate;
+            }
+
+            // baud_rate = sys_clock_freq / (8 * (baud_reg + 1))
+            // baud_reg = sys_clock_freq / (baud_rate * 8) - 1
+            let target_baud_rate = 115200;
+            let sys_clock_freq = clock_rate;
+            let baud_reg = sys_clock_freq / (target_baud_rate * 8) - 1;
+
+            this.reg(Self::AUX_MU_BAUD_REG).write(baud_reg);
+
+            {
+                let mut gpio = GPIO.get().lock();
+                gpio.set_function(14, GpioFunction::Alt5);
+                gpio.set_function(15, GpioFunction::Alt5);
+                gpio.set_pull(14, GpioPull::None);
+                gpio.set_pull(15, GpioPull::None);
+            }
+
+            this.reg(Self::AUX_MU_CNTL_REG)
+                .write((CntrlReg::RECV_ENABLE | CntrlReg::TRANS_ENABLE).bits());
         }
         this
     }
@@ -57,32 +165,66 @@ impl MiniUart {
     fn reg(&self, reg: usize) -> Volatile<u32> {
         Volatile(self.base.wrapping_byte_add(reg).cast::<u32>())
     }
-    unsafe fn transmit_fifo_full(&self) -> bool {
-        (unsafe { self.reg(Self::AUX_MU_LSR_REG).read() } & (1 << 5)) == 0
+
+    unsafe fn read_lsr(&mut self) -> LsrReg {
+        LsrReg::from_bits_retain(unsafe { self.reg(Self::AUX_MU_LSR_REG).read() })
     }
-    unsafe fn receive_fifo_empty(&self) -> bool {
-        (unsafe { self.reg(Self::AUX_MU_LSR_REG).read() } & 0b1) == 0
-    }
+
     pub fn writec(&mut self, c: u8) {
         unsafe {
-            while self.transmit_fifo_full() {}
+            loop {
+                let lsr = self.read_lsr();
+                if lsr.contains(LsrReg::RECV_OVER) {
+                    // !!!
+                }
+                if lsr.contains(LsrReg::TRANS_READY) {
+                    break;
+                }
+            }
             self.reg(Self::AUX_MU_IO_REG).write(c as u32);
         }
     }
     pub fn getc(&mut self) -> u8 {
         unsafe {
-            while self.receive_fifo_empty() {}
+            loop {
+                let lsr = self.read_lsr();
+                if lsr.contains(LsrReg::RECV_OVER) {
+                    // !!!
+                }
+                if lsr.contains(LsrReg::DATA_READY) {
+                    break;
+                }
+            }
             self.reg(Self::AUX_MU_IO_REG).read() as u8
         }
     }
     pub fn try_getc(&mut self) -> Option<u8> {
         unsafe {
-            if self.receive_fifo_empty() {
-                None
-            } else {
+            let lsr = self.read_lsr();
+            if lsr.contains(LsrReg::RECV_OVER) {
+                // !!!
+            }
+            if lsr.contains(LsrReg::DATA_READY) {
                 Some(self.reg(Self::AUX_MU_IO_REG).read() as u8)
+            } else {
+                None
             }
         }
+    }
+
+    pub fn write_bytes(&mut self, bytes: &[u8]) {
+        for b in bytes {
+            self.writec(*b);
+        }
+        // if super::CONSOLE.is_initialized() {
+        //     let mut console = super::CONSOLE.get().lock();
+        //     console.input(bytes);
+        //     if bytes.contains(&b'\n') {
+        //         console.render();
+        //     }
+        //     drop(console);
+        //     crate::sync::spin_sleep(3000);
+        // }
     }
 }
 
@@ -90,19 +232,15 @@ unsafe impl Send for MiniUart {}
 
 impl core::fmt::Write for MiniUart {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
-        for b in s.bytes() {
-            self.writec(b);
-        }
+        self.write_bytes(s.as_bytes());
         Ok(())
     }
 }
 
-impl core::fmt::Write for &SpinLock<MiniUart> {
+impl core::fmt::Write for &MiniUartLock {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
         let mut inner = self.lock();
-        for b in s.bytes() {
-            inner.writec(b);
-        }
+        inner.write_bytes(s.as_bytes());
         Ok(())
     }
     fn write_fmt(&mut self, args: core::fmt::Arguments<'_>) -> core::fmt::Result {

--- a/crates/kernel/src/device/gpio.rs
+++ b/crates/kernel/src/device/gpio.rs
@@ -60,20 +60,6 @@ impl bcm2711_gpio_driver {
         Self { base_addr }
     }
 
-    pub unsafe fn init_with_defaults(base_addr: *mut (), apply_defaults: bool) -> Self {
-        let mut driver = bcm2711_gpio_driver { base_addr };
-
-        if apply_defaults {
-            // Set UART pins
-            driver.set_function(14, GpioFunction::Alt0); // UART TX
-            driver.set_function(15, GpioFunction::Alt0); // UART RX
-
-            // Add more defaults
-        }
-
-        driver
-    }
-
     fn reg_fsel(&self, index: usize) -> Volatile<u32> {
         Volatile(
             self.base_addr

--- a/crates/kernel/src/device/macros.rs
+++ b/crates/kernel/src/device/macros.rs
@@ -1,0 +1,15 @@
+#[macro_export]
+macro_rules! print {
+    ($($arg:tt)*) => {{
+        use core::fmt::Write;
+        write!($crate::device::bcm2835_aux::MINI_UART.get(), $($arg)*).ok();
+    }};
+}
+
+#[macro_export]
+macro_rules! println {
+    ($($arg:tt)*) => {{
+        use core::fmt::Write;
+        writeln!($crate::device::bcm2835_aux::MINI_UART.get(), $($arg)*).ok();
+    }};
+}

--- a/crates/kernel/src/device/uart.rs
+++ b/crates/kernel/src/device/uart.rs
@@ -160,28 +160,11 @@ impl core::fmt::Write for UARTInner {
 impl core::fmt::Write for &UARTLock {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
         let mut inner = self.lock();
-        for b in s.bytes() {
-            inner.writec(b);
-        }
+        inner.write_bytes(s.as_bytes());
         Ok(())
     }
     fn write_fmt(&mut self, args: core::fmt::Arguments<'_>) -> core::fmt::Result {
         let mut inner = self.lock();
         inner.write_fmt(args)
     }
-}
-
-#[macro_export]
-macro_rules! print {
-    ($($arg:tt)*) => {{
-        use core::fmt::Write;
-        write!($crate::device::uart::UART.get(), $($arg)*).ok();
-    }};
-}
-#[macro_export]
-macro_rules! println {
-    ($($arg:tt)*) => {{
-        use core::fmt::Write;
-        writeln!($crate::device::uart::UART.get(), $($arg)*).ok();
-    }};
 }

--- a/crates/kernel/src/process/fd.rs
+++ b/crates/kernel/src/process/fd.rs
@@ -119,7 +119,7 @@ impl FileDescriptor for DummyFd {
     }
 }
 
-pub struct UartFd(pub &'static crate::device::uart::UARTLock);
+pub struct UartFd(pub &'static crate::device::bcm2835_aux::MiniUartLock);
 
 const READ_NO_BLOCK: bool = true;
 

--- a/crates/kernel/src/runtime.rs
+++ b/crates/kernel/src/runtime.rs
@@ -3,7 +3,7 @@
 #[unsafe(no_mangle)]
 fn panic_handler(info: &core::panic::PanicInfo) -> ! {
     use crate::arch::halt;
-    use crate::uart;
+    use crate::device::bcm2835_aux::MINI_UART;
     use core::sync::atomic;
 
     static PANICKING: atomic::AtomicBool = atomic::AtomicBool::new(false);
@@ -16,9 +16,9 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
         Some(loc) => (loc.file(), loc.line(), loc.column()),
         _ => ("unknown", 0, 0),
     };
-    if uart::UART.is_initialized() {
+    if MINI_UART.is_initialized() {
         use core::fmt::Write;
-        let uart = uart::UART.get();
+        let uart = MINI_UART.get();
         // Bypass the UART lock to print the panic message; this isn't sound,
         // but the UART struct only uses mutability to access to the MMIO,
         // so it shouldn't cause issues (beyond the fact that it's already


### PR DESCRIPTION
This works on my hardware, but it's probably good to test it on other hardware to make sure.

This sets up the Mini UART on pins 14/15, with a 115200 baud rate, 8 bit data, and 1 stop bit.

(Note when setting this up on hardware, you generally need to connect your usb adapter's RX pin to the pi's TX pin 14, and the adapter's TX pin to the pi's RX pin 15.)